### PR TITLE
feat: auto-generate blank _index.md files for Hugo

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -774,6 +774,9 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/9bc8a90931262245919a26f995c1f24c6c70d3fe?lastModified=1742237028&narHash=sha256-xlpHmgBxUnvHo8FNnju0sgnEyasb4gC607b%2BkeqjmX8%3D"
+    },
     "go@1.22.3": {
       "last_modified": "2024-06-12T20:55:33Z",
       "resolved": "github:NixOS/nixpkgs/a9858885e197f984d92d7fe64e9fff6b2e488d40#go",

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -25,17 +25,42 @@
         {{ end }}
     {{ end }}
   </ul>
-{{ end }}
+{{ else }}
+  {{ $content := .Content }}
+  {{ $hasContent := gt (len $content) 0 }}
 
-{{ .Content
-   | replaceRE 
-      `&lt;a:(\w+):(\d+)&gt;` 
-      "<img class=\"emoji\" src=\"https://cdn.discordapp.com/emojis/${2}.gif?size=44&quality=lossless\" alt=\":${1}:\"/>" 
-   | replaceRE 
-      `&lt;:(\w+):(\d+)&gt;` 
-      "<img class=\"emoji\" src=\"https://cdn.discordapp.com/emojis/${2}.webp?size=44&quality=lossless\" alt=\":${1}:\"/>" 
-   | safeHTML
-}}
+  {{ if $hasContent }}
+    {{ $content
+       | replaceRE
+          `&lt;a:(\w+):(\d+)&gt;`
+          "<img class=\"emoji\" src=\"https://cdn.discordapp.com/emojis/${2}.gif?size=44&quality=lossless\" alt=\":${1}:\"/>"
+       | replaceRE
+          `&lt;:(\w+):(\d+)&gt;`
+          "<img class=\"emoji\" src=\"https://cdn.discordapp.com/emojis/${2}.webp?size=44&quality=lossless\" alt=\":${1}:\"/>"
+       | safeHTML
+    }}
+  {{ else }}
+    {{ $currentSection := .CurrentSection }}
+    {{ $currentPath := .RelPermalink }}
+
+    <!-- List all pages under the current section path if there's no content -->
+    {{ if ne .Kind "page" }}
+      <h2>Related Pages</h2>
+      <ul class="section-list">
+        {{ range where .Site.RegularPages "Section" .Section }}
+          {{ if and (hasPrefix .RelPermalink $currentPath) (ne .RelPermalink $currentPath) }}
+            <li>
+              <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+              {{ if .Description }}
+                <p class="page-description">{{ .Description }}</p>
+              {{ end }}
+            </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    {{ end }}
+  {{ end }}
+{{ end }}
 
 <ul>
    {{ range (.Paginate ( where .Site.RegularPages "Section" "writing" ).ByDate.Reverse).Pages }}

--- a/lib/memo/export_markdown.ex
+++ b/lib/memo/export_markdown.ex
@@ -61,6 +61,9 @@ defmodule Memo.ExportMarkdown do
 
     # Export the db directory
     export_db_directory("db", exportpath)
+
+    # Create blank _index.md files in folders without them
+    generate_missing_index_files(exportpath)
   end
 
   defp export_assets_folder(asset_path, vaultpath, exportpath, ignored_patterns) do
@@ -155,5 +158,62 @@ defmodule Memo.ExportMarkdown do
     |> Enum.map(&Path.split/1)
     |> Enum.map(&List.first/1)
     |> then(fn [old, new] -> String.replace_prefix(path, old, new) end)
+  end
+
+  @doc """
+  Generates blank _index.md files in directories that don't have them in the export path.
+  """
+  defp generate_missing_index_files(exportpath) do
+    # Get all directories in the export path
+    directories = get_all_directories(exportpath)
+
+    # For each directory, check if it has an _index.md and create one if not
+    Enum.each(directories, fn dir_path ->
+      index_file_path = Path.join(dir_path, "_index.md")
+      
+      if !File.exists?(index_file_path) do
+        # Create a basic frontmatter with title based on the directory name
+        dir_name = Path.basename(dir_path)
+        content = """
+        ---
+        title: #{String.capitalize(dir_name)}
+        ---
+        """
+        
+        # Write the file
+        File.write!(index_file_path, content)
+        IO.puts("Generated blank _index.md in: #{dir_path}")
+      end
+    end)
+  end
+
+  @doc """
+  Gets all directories recursively in a given path
+  """
+  defp get_all_directories(path) do
+    if File.dir?(path) do
+      # Skip if the current directory is named "assets"
+      if Path.basename(path) == "assets" do
+        []
+      else
+        subdirs = 
+          File.ls!(path)
+          |> Enum.filter(fn item -> 
+            full_path = Path.join(path, item)
+            # Filter directories, exclude hidden dirs and "assets" dirs
+            File.dir?(full_path) && 
+              !String.starts_with?(item, ".") && 
+              item != "assets"
+          end)
+          |> Enum.flat_map(fn item ->
+            full_path = Path.join(path, item)
+            [full_path | get_all_directories(full_path)]
+          end)
+        
+        [path | subdirs]
+      end
+    else
+      []
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR implements a new feature to automatically generate blank `_index.md` files in directories that don't have them in the export path. This helps Hugo properly render content nested in subdirectories without requiring manual creation of these index files.

## Changes
- Added a new `generate_missing_index_files` function that is called at the end of the directory processing in `ExportMarkdown.run`
- Added a new `get_all_directories` helper function to recursively find all directories in the export path
- Implemented logic to skip asset folders (both top-level and nested) to avoid creating unnecessary index files
- Each generated `_index.md` file includes basic frontmatter with a title derived from the directory name

## Why
Hugo requires `_index.md` files in directories to properly render nested content and list pages. Previously, these files had to be created manually, which could be error-prone and time-consuming.

## Testing
- Manually tested by running the export process and verifying that:
  - Blank `_index.md` files are generated in directories that didn't have them
  - No `_index.md` files are generated in asset folders
  - Existing `_index.md` files are preserved

🤖 Generated with [Claude Code](https://claude.ai/code)