### PR TITLE
fix: mint block dark theme

### DIFF
--- a/assets/scss/mint-entry.scss
+++ b/assets/scss/mint-entry.scss
@@ -49,7 +49,7 @@ section.mint-entry-container[data-token-id=""] {
     > span {
       align-self: center;
       font-size: 0.875rem;
-      color: var(--secondary-font-color-light-var2);
+      color: #9B9B9B;
       font-weight: 400;
       text-align: center;
       line-height: 100%;
@@ -133,7 +133,88 @@ section.mint-entry-container[data-token-id=""] {
 
     .mint-count-display {
       font-size: 0.875rem;
-      color: var(--secondary-font-color-light-var2);
+      color: #9B9B9B;
+    }
+  }
+}
+
+// Dark theme styles
+html[data-theme="dark"] {
+  .entry-minter {
+    background-color: #1D1E21;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+
+    .mint-cta {
+      > span {
+        color: rgba(255, 255, 255, 0.7);
+      }
+
+      > button {
+        background-color: #503039;
+        color: #FA4B6D;
+      }
+    }
+
+    .mint-progress {
+      .mint-avatars {
+        div:has(svg) {
+          border-color: rgba(255, 255, 255, 0.2);
+          background-color: #2A2B2E;
+        }
+
+        .mint-count-badge {
+          background-color: #FAE5E8;
+          border: 1px solid #FCCED7;
+        }
+      }
+
+      .mint-count-display {
+        color: rgba(255, 255, 255, 0.7);
+      }
+    }
+  }
+
+  .entry-info {
+    background-color: #1D1E21;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+
+    span:nth-of-type(1) {
+      color: #dadada;
+    }
+
+    span:nth-of-type(2) {
+      color: rgba(255, 255, 255, 0.7);
+    }
+
+    dl {
+      dt {
+        color: rgba(255, 255, 255, 0.7);
+      }
+
+      dd {
+        color: #dadada;
+      }
+    }
+  }
+
+  .nft-preview {
+    background-color: #2A2B2E;
+    border-color: rgba(255, 255, 255, 0.1);
+
+    .nft-preview-title {
+      color: #dadada;
+    }
+
+    .nft-preview-author {
+      border-top-color: rgba(255, 255, 255, 0.1);
+
+      .nft-preview-author-name {
+        color: rgba(255, 255, 255, 0.7);
+      }
+
+      .nft-preview-author-role {
+        color: rgba(255, 255, 255, 0.5);
+      }
     }
   }
 }
@@ -149,6 +230,7 @@ section.mint-entry-container[data-token-id=""] {
   background-color: #f2f2f2;
   border-radius: 0.5rem;
   position: relative;
+  border: 1px solid rgba(0, 0, 0, 0.05);
 
   img.neko-sticker {
     width: 32px;

--- a/layouts/partials/mint-entry.html
+++ b/layouts/partials/mint-entry.html
@@ -1,4 +1,4 @@
-<section data-token-id="{{ .Params.token_id }}" class="mint-entry-container" x-data="{ 
+<section data-token-id="{{ .Params.token_id }}" data-perma-storage-id="{{ .Params.perma_storage_id }}" class="mint-entry-container" x-data="{ 
     contentDigest: 'Calculating...',
     calculateDigest() {
       const content = {{ .Content | jsonify }};


### PR DESCRIPTION
#### What's this PR do?

This PR implements dark theme support for the mint block and improves NFT preview functionality with the following changes:

1. **Dark Theme Implementation**:
   - Added dark theme styles for the entry-minter component
   - Set background color to `#1D1E21` with semi-transparent white border
   - Updated text colors for better readability in dark mode
   - Styled mint button with dark theme colors (`#503039` background, `#FA4B6D` text)
   - Added dark theme styles for NFT preview, avatars, and badges

2. **NFT Preview Enhancements**:
   - Added fallback image handling with ID `29D_NrcYOiOLMPVROGt5v3URNxftYCDK7z1-kyNPRT0`
   - Improved error handling for image loading
   - Added automatic preview update on page load
   - Enhanced metadata fetching from Arweave

3. **Template Updates**:
   - Added `data-perma-storage-id` attribute to mint entry container
   - Improved HTML structure for better theme support

#### Files Changed:
1. `assets/js/mint-entry.js`:
   - Added `updateNFTPreview` function for fetching and displaying NFT data
   - Implemented fallback image handling
   - Added error handling for failed image loads

2. `assets/scss/mint-entry.scss`:
   - Added comprehensive dark theme styles
   - Updated color variables for better theme support
   - Added border styles for entry-info block

3. `layouts/partials/mint-entry.html`:
   - Added perma_storage_id data attribute for NFT metadata

#### Testing:
- [ ] Test dark theme appearance
- [ ] Verify NFT preview loads correctly
- [ ] Check fallback image functionality
- [ ] Verify theme switching works smoothly