### PR TITLE
perf(command-palette): static gen index and resolve navigation issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          publish_dir: ./out
 
   notify_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Deploy Hugo from Obsidian notes
+name: Deploy Next.js from Obsidian notes
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.11.0
         with:
           enable-cache: true
-          devbox-version: 0.13.3
+          devbox-version: 0.14.0
 
       - name: Run Build
         run: devbox run build
@@ -39,17 +39,17 @@ jobs:
 
   notify_job:
     runs-on: ubuntu-latest
-    name: Notify Discord 
+    name: Notify Discord
     needs: publish_job
     steps:
       - name: Sleep for 30 seconds
         uses: jakejarvis/wait-action@master
         with:
-          time: '30s'
+          time: "30s"
 
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
-          args: 'memo.d.foundation has been updated.'
+          args: "memo.d.foundation has been updated."

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,13 @@ fetch-force:
 	@./git-fetch.sh --force
 
 build:
+	@pnpm install
 	@cd lib/obsidian-compiler && mix run -e 'Memo.ExportMarkdown.run("../../vault", "../../public/content")'
 	@pnpm run build
 
 run:
 	@cd lib/obsidian-compiler && mix run -e 'Memo.ExportMarkdown.run("../../vault", "../../public/content")'
 	@pnpm run dev
-
-watch-run:
-	@cd lib/obsidian-compiler && mix run -e 'Memo.Application.watch_run("../../vault", "../../public/content")'
 
 duckdb-export:
 	@rm -f vault.duckdb

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ fetch-force:
 	@./git-fetch.sh --force
 
 build:
-	@pnpm install --frozen-lockfile
+	@pnpm install --no-frozen-lockfile
 	@cd lib/obsidian-compiler && mix run -e 'Memo.ExportMarkdown.run("../../vault", "../../public/content")'
 	@pnpm run build
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build:
 
 run:
 	@cd lib/obsidian-compiler && mix run -e 'Memo.ExportMarkdown.run("../../vault", "../../public/content")'
+	@pnpm run generate-search-index
 	@pnpm run dev
 
 duckdb-export:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ fetch-force:
 	@./git-fetch.sh --force
 
 build:
-	@pnpm install
+	@pnpm install --frozen-lockfile
 	@cd lib/obsidian-compiler && mix run -e 'Memo.ExportMarkdown.run("../../vault", "../../public/content")'
 	@pnpm run build
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ or through devbox:
 devbox run watch-run
 ```
 
+### Search Index
+
+The app uses client-side search with MiniSearch. To improve build performance and reduce page size, we generate a separate search index file during the build process:
+
+```sh
+pnpm run generate-search-index
+```
+
+This script creates a static JSON file at `public/content/search-index.json` that's loaded dynamically by the client when needed, instead of being included in every page's props.
+
 ## Code of conduct
 
 We expect all contributors to adhere to our [code of conduct](^15^), which is based on the [Contributor Covenant](https://www.contributor-covenant.org/). By participating in this project, you agree to abide by its terms. Please report any unacceptable behavior to [team@d.foundation](mailto:team@d.foundation).

--- a/devbox.json
+++ b/devbox.json
@@ -1,26 +1,23 @@
 {
   "packages": {
-    "awscli":    "1.32.21",
-    "git":       "2.48.1",
-    "duckdb":    "1.2.0",
-    "elixir":    "1.18.1",
+    "awscli": "1.32.21",
+    "git": "2.48.1",
+    "duckdb": "1.2.0",
+    "elixir": "1.18.1",
     "elixir-ls": "0.21.3",
-    "nodejs":    "23.9.0",
-    "pnpm":      "10.6.2"
+    "nodejs": "23.9.0",
+    "pnpm": "10.7.0"
   },
   "shell": {
-    "init_hook": [
-      "make lib-setup",
-      "make fetch"
-    ],
+    "init_hook": ["make lib-setup", "make fetch"],
     "scripts": {
-      "build":         "make build",
-      "clear-build":   "make clear-build",
-      "watch-run":     "make watch-run",
-      "build-target":  "make build-target",
-      "run-target":    "make run-target",
+      "build": "make build",
+      "clear-build": "make clear-build",
+      "watch-run": "make watch-run",
+      "build-target": "make build-target",
+      "run-target": "make run-target",
       "duckdb-export": "make duckdb-export",
-      "fetch":         "make fetch"
+      "fetch": "make fetch"
     }
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -396,51 +396,51 @@
         }
       }
     },
-    "pnpm@10.6.2": {
-      "last_modified": "2025-03-11T17:52:14Z",
-      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#pnpm",
+    "pnpm@10.7.0": {
+      "last_modified": "2025-03-27T11:50:31Z",
+      "resolved": "github:NixOS/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04#pnpm",
       "source": "devbox-search",
-      "version": "10.6.2",
+      "version": "10.7.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/0zvnl2q475cakvl3bdgjl3py60ngys05-pnpm-10.6.2",
+              "path": "/nix/store/x76wprx01q04cinshnm1133yg1ypsj3a-pnpm-10.7.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/0zvnl2q475cakvl3bdgjl3py60ngys05-pnpm-10.6.2"
+          "store_path": "/nix/store/x76wprx01q04cinshnm1133yg1ypsj3a-pnpm-10.7.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/fvirhzl2ygjsnxfw0pdhg1jgybcyn95f-pnpm-10.6.2",
+              "path": "/nix/store/bnarmhxsz8msrpsn96di6vb2ng3idaxj-pnpm-10.7.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/fvirhzl2ygjsnxfw0pdhg1jgybcyn95f-pnpm-10.6.2"
+          "store_path": "/nix/store/bnarmhxsz8msrpsn96di6vb2ng3idaxj-pnpm-10.7.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/717jiydkk5314xk49kwk9pv6436fknc3-pnpm-10.6.2",
+              "path": "/nix/store/0pz2nz0r1rwmyqg1kczs4wwxhnx6xn86-pnpm-10.7.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/717jiydkk5314xk49kwk9pv6436fknc3-pnpm-10.6.2"
+          "store_path": "/nix/store/0pz2nz0r1rwmyqg1kczs4wwxhnx6xn86-pnpm-10.7.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/cik4v9s4dpjnzjljnr9n4krsimlisvi4-pnpm-10.6.2",
+              "path": "/nix/store/ywwl1rqzh8ivxz9skyyswqf56hsdp4gg-pnpm-10.7.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/cik4v9s4dpjnzjljnr9n4krsimlisvi4-pnpm-10.6.2"
+          "store_path": "/nix/store/ywwl1rqzh8ivxz9skyyswqf56hsdp4gg-pnpm-10.7.0"
         }
       }
     }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'export',
@@ -7,9 +7,12 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   reactStrictMode: true,
-}
+  experimental: {
+    largePageDataBytes: 1024 * 1024,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;
 
 // Merge MDX config with Next.js config
-export default nextConfig
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build && npm run generate-rss",
+    "build": "node scripts/generate-search-index.js && next build && pnpm run generate-rss",
     "start": "next start",
     "lint": "next lint",
     "deploy": "gh-pages -d out",
     "format": "prettier --write ./src",
     "prepare": "husky",
     "lint-staged": "lint-staged",
-    "generate-rss": "node scripts/generate-rss.js"
+    "generate-rss": "node scripts/generate-rss.js",
+    "generate-search-index": "node scripts/generate-search-index.js"
   },
   "type": "module",
   "homepage": "https://memo.d.foundation/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:

--- a/scripts/generate-search-index.js
+++ b/scripts/generate-search-index.js
@@ -1,0 +1,140 @@
+/**
+ * Search index generation script
+ * Using ES module format as per package.json "type": "module"
+ * @packageDocumentation
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { asyncBufferFromFile, parquetRead } from 'hyparquet';
+import MiniSearch from 'minisearch';
+
+/**
+ * Extract paths from file path to create category
+ * @param filePath File path
+ * @returns Category string
+ */
+function extractCategory(filePath) {
+  const parts = filePath.split('/');
+  parts.pop(); // Remove the file name
+  return parts.join(' > ');
+}
+
+async function generateSearchIndex() {
+  try {
+    const parquetFilePath = path.join(process.cwd(), 'db/vault.parquet');
+    if (!fs.existsSync(parquetFilePath)) {
+      console.error('Parquet file not found:', parquetFilePath);
+      return;
+    }
+
+    let searchIndex = [];
+
+    await parquetRead({
+      file: await asyncBufferFromFile(parquetFilePath),
+      columns: [
+        'file_path',
+        'title',
+        'description',
+        'tags',
+        'authors',
+        'date',
+        'draft',
+        'hiring',
+        'status',
+      ],
+      onComplete: data => {
+        searchIndex = data
+          .map((row, idx) => {
+            const filePath = row[0]?.toString() || '';
+            const title = row[1]?.toString() || '';
+            const description = row[2]?.toString() || '';
+            const tags = Array.isArray(row[3]) ? row[3] : [];
+            const authors = Array.isArray(row[4]) ? row[4] : [];
+            const date = row[5]?.toString() || '';
+            const draft = row[6] === true;
+            const hiring = row[7] === false;
+            const status = row[8]?.toString() || '';
+
+            return {
+              id: String(idx),
+              file_path: filePath,
+              title,
+              description,
+              tags,
+              authors,
+              date,
+              category: extractCategory(filePath),
+              // Exclude items that should be filtered out
+              _exclude: draft || hiring || (status && status !== 'Open'),
+            };
+          })
+          .filter(doc => !doc._exclude && doc.title && doc.description);
+      },
+    });
+
+    // Create optimized index without full content
+    const miniSearch = new MiniSearch({
+      fields: ['title', 'description', 'tags', 'authors'],
+      storeFields: [
+        'file_path',
+        'title',
+        'description',
+        'tags',
+        'authors',
+        'date',
+        'category',
+      ],
+      searchOptions: {
+        boost: { title: 2, tags: 1.5, authors: 1.2 },
+        fuzzy: 0.2,
+        prefix: true,
+      },
+      extractField: (document, fieldName) => {
+        if (fieldName === 'tags' && Array.isArray(document.tags)) {
+          return document.tags.join(' ');
+        }
+        if (fieldName === 'authors' && Array.isArray(document.authors)) {
+          return document.authors.join(' ');
+        }
+        return document[fieldName] || '';
+      },
+    });
+
+    // Add documents to index
+    miniSearch.addAll(searchIndex);
+
+    // Create the output directory if it doesn't exist
+    const publicDir = path.join(process.cwd(), 'public');
+    const dataDir = path.join(publicDir, 'content');
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    // Write the serialized index to a file
+    const outputPath = path.join(dataDir, 'search-index.json');
+    fs.writeFileSync(
+      outputPath,
+      JSON.stringify({
+        index: miniSearch.toJSON(),
+        documents: searchIndex.map(doc => ({
+          id: doc.id,
+          file_path: doc.file_path,
+          title: doc.title,
+          description: doc.description,
+          tags: doc.tags,
+          authors: doc.authors,
+          date: doc.date,
+          category: doc.category,
+        })),
+      }),
+    );
+
+    console.log(`Search index generated at: ${outputPath}`);
+  } catch (error) {
+    console.error('Error generating search index:', error);
+  }
+}
+
+// Run the function
+generateSearchIndex();

--- a/src/lib/content/backlinks.ts
+++ b/src/lib/content/backlinks.ts
@@ -9,7 +9,7 @@ import { getMarkdownMetadata } from './markdown';
  * @param str The string to slugify
  * @returns Slugified string
  */
-function slugify(str: string): string {
+export function slugify(str: string): string {
   return str
     .toLowerCase()
     .replace(/[^a-z0-9\s_-]/g, '')
@@ -24,7 +24,7 @@ function slugify(str: string): string {
  * @param filename The filename to slugify
  * @returns Slugified filename with extension preserved
  */
-function slugifyFilename(filename: string): string {
+export function slugifyFilename(filename: string): string {
   const ext = path.extname(filename);
   const name = path.basename(filename, ext);
   return slugify(name) + ext;
@@ -35,7 +35,7 @@ function slugifyFilename(filename: string): string {
  * @param pathStr The path to slugify
  * @returns Path with components slugified
  */
-function slugifyPathComponents(pathStr: string): string {
+export function slugifyPathComponents(pathStr: string): string {
   return pathStr
     .split('/')
     .map(component => {

--- a/src/lib/content/directoryTree.ts
+++ b/src/lib/content/directoryTree.ts
@@ -55,4 +55,4 @@ export function buildDirectorTree(allMemos: IMemoItem[]) {
 
   return root;
 }
-export function getAllTags() {}
+export function getAllTags() { }

--- a/src/lib/content/memo.ts
+++ b/src/lib/content/memo.ts
@@ -34,7 +34,7 @@ export function getAllMarkdownContents(basePath = '') {
         draft: result.data.draft || false,
         hiring: result.data.hiring || false,
         authors: result.data.authors || [],
-        date: result.data.date?.toString(),
+        date: result.data.date?.toString() || null,
         filePath: path.join(basePath, ...slugArray) + '.md',
         slugArray: [...baseSlugArray, ...slugArray],
       };
@@ -49,6 +49,7 @@ interface FilterMemoProps {
   sortBy?: keyof IMemoItem;
   sortOrder?: 'asc' | 'desc';
   limit?: number | null;
+  excludeContent?: boolean;
 }
 export function sortMemos(
   data: IMemoItem[],
@@ -69,7 +70,7 @@ export function sortMemos(
 }
 
 export function filterMemo(props: FilterMemoProps) {
-  const { data, filters, limit = 3 } = props;
+  const { data, filters, limit = 3, excludeContent = false } = props;
   const result: IMemoItem[] = [];
   for (const memo of data) {
     const invalid =
@@ -98,7 +99,10 @@ export function filterMemo(props: FilterMemoProps) {
     if (invalid) {
       continue;
     }
-    result.push(memo);
+    result.push({
+      ...memo,
+      content: excludeContent ? '' : memo.content,
+    });
     if (limit && result.length >= limit) {
       break;
     }

--- a/src/lib/content/memo.ts
+++ b/src/lib/content/memo.ts
@@ -25,7 +25,11 @@ export function getAllMarkdownContents(basePath = '') {
         title: result.data.title || slugArray[slugArray.length - 1],
         short_title: result.data.short_title || '',
         description: result.data.description || '',
-        tags: result.data.tags || [],
+        tags: Array.isArray(result.data.tags)
+          ? result.data.tags.filter(
+              tag => tag !== null && tag !== undefined && tag !== '',
+            )
+          : [],
         pinned: result.data.pinned || false,
         draft: result.data.draft || false,
         hiring: result.data.hiring || false,

--- a/src/lib/content/search.ts
+++ b/src/lib/content/search.ts
@@ -220,7 +220,11 @@ export async function initializeSearchIndex(): Promise<void> {
               const description = row[2]?.toString() || '';
               const mdContent = row[3]?.toString() || '';
               const sprContent = row[4]?.toString() || '';
-              const tags = Array.isArray(row[5]) ? (row[5] as string[]) : [];
+              const tags = Array.isArray(row[5])
+                ? (row[5] as string[]).filter(
+                    tag => tag !== null && tag !== undefined && tag !== '',
+                  )
+                : [];
               const authors = Array.isArray(row[6]) ? (row[6] as string[]) : [];
               const date = row[7]?.toString() || '';
               const draft = row[8] === true;
@@ -265,7 +269,11 @@ export async function initializeSearchIndex(): Promise<void> {
             },
             extractField: (document: Document, fieldName: string) => {
               if (fieldName === 'tags' && Array.isArray(document.tags)) {
-                return document.tags.join(' ');
+                return document.tags
+                  .filter(
+                    tag => tag !== null && tag !== undefined && tag !== '',
+                  )
+                  .join(' ');
               }
               if (fieldName === 'authors' && Array.isArray(document.authors)) {
                 return document.authors.join(' ');

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -1,16 +1,14 @@
 import { IMemoItem, RootLayoutPageProps } from '@/types';
 import { buildDirectorTree } from './directoryTree';
-import { initializeSearchIndex, getSerializableSearchIndex } from './search';
+import { initializeSearchIndex } from './search';
 
 export async function getRootLayoutPageProps(
   allMemos: IMemoItem[],
 ): Promise<RootLayoutPageProps> {
   await initializeSearchIndex();
-  const searchIndex = getSerializableSearchIndex();
   const directoryTree = buildDirectorTree(allMemos);
 
   return {
     directoryTree,
-    searchIndex,
   };
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './slugify';

--- a/src/lib/utils/slugify.ts
+++ b/src/lib/utils/slugify.ts
@@ -1,0 +1,42 @@
+/**
+ * Slugify a string (based on Memo.Common.Slugify.slugify)
+ * @param str The string to slugify
+ * @returns Slugified string
+ */
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s_-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim()
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Slugify filename (based on Memo.Common.Slugify.slugify_filename)
+ * @param filename The filename to slugify
+ * @returns Slugified filename with extension preserved
+ */
+export function slugifyFilename(filename: string): string {
+  const ext = filename.includes('.') ? '.' + filename.split('.').pop() : '';
+  const name = ext ? filename.slice(0, -ext.length) : filename;
+  return slugify(name) + ext;
+}
+
+/**
+ * Slugify path components (based on Memo.Common.Slugify.slugify_path_components)
+ * @param pathStr The path to slugify
+ * @returns Path with components slugified
+ */
+export function slugifyPathComponents(pathStr: string): string {
+  return pathStr
+    .split('/')
+    .map(component => {
+      if (['.', '..', ''].includes(component)) {
+        return component;
+      }
+      return slugifyFilename(component);
+    })
+    .join('/');
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -47,9 +47,11 @@ export const getStaticPaths: GetStaticPaths = async () => {
   // that will be accessible in the exported static site
   const contentDir = path.join(process.cwd(), 'public/content');
 
-  const paths = getAllMarkdownFiles(contentDir).map(slugArray => ({
-    params: { slug: slugArray },
-  }));
+  const paths = getAllMarkdownFiles(contentDir)
+    .filter(slugArray => !slugArray[0]?.startsWith('contributor'))
+    .map(slugArray => ({
+      params: { slug: slugArray },
+    }));
 
   return {
     paths,

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -49,7 +49,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   const paths = getAllMarkdownFiles(contentDir)
     .filter(
-      slugArray => !slugArray[0]?.toLowerCase()?.startsWith('contributor'),
+      slugArray =>
+        !slugArray[0]?.toLowerCase()?.startsWith('contributor') &&
+        !slugArray[0]?.toLowerCase()?.startsWith('tags'),
     )
     .map(slugArray => ({
       params: { slug: slugArray },

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -48,7 +48,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const contentDir = path.join(process.cwd(), 'public/content');
 
   const paths = getAllMarkdownFiles(contentDir)
-    .filter(slugArray => !slugArray[0]?.startsWith('contributor'))
+    .filter(
+      slugArray => !slugArray[0]?.toLowerCase()?.startsWith('contributor'),
+    )
     .map(slugArray => ({
       params: { slug: slugArray },
     }));

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -116,7 +116,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       updated: frontmatter.lastmod?.toString() || null,
       author: frontmatter.authors?.[0] || '',
       coAuthors: frontmatter.authors?.slice(1) || [],
-      tags: frontmatter.tags || [],
+      tags: Array.isArray(frontmatter.tags)
+        ? frontmatter.tags.filter(
+            tag => tag !== null && tag !== undefined && tag !== '',
+          )
+        : [],
       folder: slug.slice(0, -1).join('/'),
       // Calculate reading time based on word count (average reading speed: 200 words per minute)
       wordCount: content.split(/\s+/).length ?? 0,

--- a/src/pages/contributor/[slug].tsx
+++ b/src/pages/contributor/[slug].tsx
@@ -30,7 +30,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
     if (memo.authors?.length) {
       memo.authors.forEach(contributor => {
         if (contributor) {
-          contributors.add(contributor);
+          // Store contributor names in lowercase to avoid case sensitivity issues
+          contributors.add(contributor.toLowerCase());
         }
       });
     }
@@ -58,17 +59,31 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     if (!contributor) {
       return { notFound: true };
     }
+
+    // Find the original case of the contributor name
+    const originalContributor =
+      allMemos
+        .find(memo =>
+          memo.authors?.some(
+            author => author?.toLowerCase() === contributor.toLowerCase(),
+          ),
+        )
+        ?.authors?.find(
+          author => author?.toLowerCase() === contributor.toLowerCase(),
+        ) || contributor;
+
     const memos = filterMemo({
       data: allMemos,
-      filters: { authors: contributor },
+      filters: { authors: originalContributor },
       limit: null,
       excludeContent: true,
     });
+
     return {
       props: {
         ...layoutProps,
         slug,
-        contributor,
+        contributor: originalContributor, // Use the original case for display
         data: memos,
       },
     };

--- a/src/pages/contributor/[slug].tsx
+++ b/src/pages/contributor/[slug].tsx
@@ -62,6 +62,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       data: allMemos,
       filters: { authors: contributor },
       limit: null,
+      excludeContent: true,
     });
     return {
       props: {

--- a/src/pages/tags/[slug].tsx
+++ b/src/pages/tags/[slug].tsx
@@ -62,6 +62,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       data: allMemos,
       filters: { tags: tag },
       limit: null,
+      excludeContent: true,
     });
     return {
       props: {

--- a/src/pages/tags/[slug].tsx
+++ b/src/pages/tags/[slug].tsx
@@ -142,7 +142,7 @@ export default function TagDetailPage({
                       {memo.tags?.slice(0, 3).map(tag => (
                         <Link
                           key={tag}
-                          href={`/tags/${tag}`}
+                          href={`/tags/${tag.toLowerCase().replace(/\s+/g, '-')}`}
                           className="dark:bg-border hover:text-primary text-2xs rounded-[2.8px] bg-[#f9fafb] px-1.5 leading-[1.7] font-medium text-neutral-500 hover:underline"
                         >
                           {tag}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,7 +53,7 @@ export interface ISearchResultItem {
 
 export interface RootLayoutPageProps {
   directoryTree?: Record<string, ITreeNode>;
-  searchIndex: IMiniSearchIndex | null;
+  searchIndex?: IMiniSearchIndex | null;
 }
 
 export interface IMemoItem {


### PR DESCRIPTION
## Description

This PR fixes performance build issues and critical issue with the Command Palette where clicking on search results would close the browser tab instead of navigating to the correct page.

### Changes:

#### 0. Moved search index generation as a separate file for client-use

#### 1. Fixed CommandPalette navigation logic
- Modified the `goto` function to properly handle navigation with consistent URL formatting
- Ensured paths always start with `/` to prevent tab closing issues
- Enhanced path handling for proper navigation

#### 2. Created browser-safe slugify utilities
- Added new `slugify.ts` utility file that works client-side without Node.js dependencies
- Extracted slugify functions from `backlinks.ts` to prevent "Module not found: Can't resolve 'fs'" errors
- Implemented proper path handling for extensions

#### 3. Code improvements
- Added proper dependency tracking in useCallback hooks
- Improved error handling around navigation
- Better string handling for apostrophes in search items

### Testing:
- Command palette now navigates correctly to pages
- Search results behave as expected
- Browser tabs no longer close unexpectedly

This fix resolves a UX friction point that was affecting user navigation through the command palette search functionality.