### PR TITLE
feat(directory-tree): display readme.md files in directory menu

### DIFF
--- a/src/components/layout/DirectoryTree.tsx
+++ b/src/components/layout/DirectoryTree.tsx
@@ -61,6 +61,14 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
     if (depth === 0 && !hasChildren) {
       return null;
     }
+
+    // Check if this is a readme entry
+    const isReadmeEntry = path.endsWith('/readme');
+    // Get parent path for readme entries
+    const linkPath = isReadmeEntry
+      ? path.substring(0, path.lastIndexOf('/'))
+      : path;
+
     return (
       <div
         key={path}
@@ -71,7 +79,7 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
         })}
       >
         <Link
-          href={path}
+          href={linkPath}
           onClick={e => {
             if (hasChildren) {
               e.preventDefault();
@@ -83,7 +91,8 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
             'flex cursor-pointer items-center gap-1 p-1.25 text-left text-xs leading-normal font-medium',
             {
               'text-muted-foreground pl-2': !hasChildren,
-              'text-primary': isActive,
+              'text-primary':
+                isActive || (isReadmeEntry && currentPath === linkPath),
             },
           )}
         >

--- a/src/lib/content/paths.ts
+++ b/src/lib/content/paths.ts
@@ -22,6 +22,9 @@ export function getAllMarkdownFiles(
   if (fs.existsSync(readmeFilePath) && basePath.length > 0) {
     // If readme.md exists, add the current directory as a path
     paths.push([...basePath]);
+
+    // Also add readme.md as a separate entry
+    paths.push([...basePath, 'readme']);
   } else if (fs.existsSync(indexFilePath) && basePath.length > 0) {
     // If _index.md exists but readme.md doesn't, add the current directory as a path
     paths.push([...basePath]);


### PR DESCRIPTION
## Description

This PR updates the directory tree menu to display `readme.md` files as separate menu items that link to their parent directory.

### Changes

1. Modified `getAllMarkdownFiles` in `paths.ts` to include readme.md files as separate entries in the path list with 'readme' slug.

2. Updated the `DirectoryTree` component to:
   - Detect readme entries by checking if the path ends with '/readme'
   - Make readme entries link to their parent directory (e.g., '/consulting/readme' links to '/consulting')
   - Keep the frontmatter title/short_title for readme files instead of hardcoding a label

### Before
Directory tree would only show:
```
/consulting
  /child
```

### After
Directory tree now shows:
```
/consulting 
  /Consulting Overview (clicking redirects to /consulting)
  /child
```

Where "Consulting Overview" is the frontmatter title of the readme.md file.

### Testing
- Directories with readme.md files now show them as clickable items in the menu
- Clicking on the readme item correctly navigates to the parent directory
- The title shown in the menu uses the frontmatter from the readme.md file