### PR TITLE
fix(content): adjust backlink path and title logic

### DIFF
--- a/src/lib/content/backlinks.ts
+++ b/src/lib/content/backlinks.ts
@@ -99,15 +99,25 @@ export async function getBacklinks(slug: string[]) {
             // Slugify the path components
             const slugifiedPath = slugifyPathComponents(filePath);
             // Remove .md extension from the output
-            const path = slugifiedPath.endsWith('.md')
+            let finalPath = slugifiedPath.endsWith('.md')
               ? slugifiedPath.slice(0, -3)
               : slugifiedPath;
+
+            // Remove trailing /readme
+            if (finalPath.endsWith('/readme')) {
+              finalPath = finalPath.slice(0, -'/readme'.length);
+            }
+
+            // Use title from parquet data if available, otherwise fallback
+            const titleFromParquet = row[2]?.toString(); // title is at index 2
+            const calculatedTitle =
+              getMarkdownMetadata(filePath).title ||
+              finalPath.split('/').pop() || // Use finalPath for fallback
+              finalPath;
+
             return {
-              title:
-                getMarkdownMetadata(filePath).title ||
-                path.split('/').pop() ||
-                path,
-              path,
+              title: titleFromParquet || calculatedTitle,
+              path: finalPath,
             };
           });
         },


### PR DESCRIPTION
This PR addresses two issues in the backlink generation logic within `src/lib/content/backlinks.ts`:

1.  **Incorrect Path for README Files:** Backlinks pointing to files named `README.md` (or similar variations like `readme.md`) were incorrectly including `/readme` in the final path (e.g., `/careers/hiring/readme`). This change ensures that such paths are correctly resolved to the parent directory (e.g., `/careers/hiring`).
2.  **Incorrect Title Display:** The title for some backlinks was defaulting to the filename component (e.g., "readme") instead of using the actual title defined in the markdown frontmatter or the database. The logic has been updated to prioritize the title fetched from the `vault.parquet` database first, then fall back to the markdown frontmatter title, and only use the path component as a last resort.

These changes improve the accuracy and presentation of backlinks in the "MENTIONED IN" section.