### PR TITLE
fix: remove trailing slashes from formatted memo paths

### DIFF
--- a/src/components/memo/utils.ts
+++ b/src/components/memo/utils.ts
@@ -28,12 +28,22 @@ export function getFirstMemoImage(
 }
 
 export function formatMemoPath(filePath: string): string {
-  const formattedPath = filePath
+  let formattedPath = filePath
     .toLowerCase()
     .replace(/\.md$/, '')
     .replace(/ /g, '-')
     .replace(/[^a-zA-Z0-9/_-]+/g, '-')
     .replace(/(-\/|-$|_index$)/g, '');
 
-  return `/${formattedPath}`;
+  // Remove trailing slash if present
+  if (formattedPath.endsWith('/')) {
+    formattedPath = formattedPath.slice(0, -1);
+  }
+
+  // Ensure the path starts with a single slash
+  if (formattedPath.startsWith('/')) {
+    return formattedPath; // Already starts with slash, return as is
+  } else {
+    return `/${formattedPath}`; // Prepend slash
+  }
 }


### PR DESCRIPTION
This PR addresses an issue where trailing slashes in URLs were causing unexpected behavior.

**Changes:**

- Modified the `formatMemoPath` function in `src/components/memo/utils.ts`.
- Added logic to explicitly remove any trailing slashes from the `formattedPath` before returning it.
- Changed the `formattedPath` variable declaration from `const` to `let` to allow modification and resolve a TypeScript error.

This ensures that all paths generated by `formatMemoPath` are correctly formatted without trailing slashes, aligning with the default Next.js behavior and resolving the associated bug.