### PR TITLE
fix: use var before being assigned in generating profiles

### DIFF
--- a/scripts/generate-user-profiles.ts
+++ b/scripts/generate-user-profiles.ts
@@ -70,8 +70,9 @@ async function getAllAuthors() {
 }
 
 async function getUserProfileByGithubUsername(githubUsername: string) {
-  let githubData: RestEndpointMethodTypes['users']['getByUsername']['response']['data'] =
-    null;
+  let githubData:
+    | RestEndpointMethodTypes['users']['getByUsername']['response']['data']
+    | null = null;
   let mochiData: MochiUserProfile | null = null;
   try {
     // Assuming the contributor slug can be used as a GitHub username


### PR DESCRIPTION
#### What's this PR do?

- [x] Add new routes for user
- [x] Add instruction for using docker-compose

#### What are the relevant Git tickets?

// Put in link to Git Issue

#### Screenshots (if appropriate)

// Use [Licecap](http://www.cockos.com/licecap/) to share a screencast gif.

#### Any background context you want to provide? (if appropriate)

- Is there a blog post?
- Does the knowledge base need an update?
- Does this add new dependencies which need to be added to?
