### PR TITLE
feat: improve github rate limit handling for profile generation

### DIFF
--- a/public/content/userProfiles.json
+++ b/public/content/userProfiles.json
@@ -1,0 +1,3806 @@
+{
+  "data": {
+    "zlatanpham": {
+      "id": "43678",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T11:31:03.137327Z",
+      "associated_accounts": [
+        {
+          "id": "43678",
+          "profile_id": "43678",
+          "platform": "discord",
+          "platform_identifier": "790170208228212766",
+          "platform_metadata": {
+            "username": "thanh.pham"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:23.382025Z",
+          "updated_at": "2025-04-24T10:47:23.562184Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1716280949383106560",
+          "profile_id": "43678",
+          "platform": "evm-chain",
+          "platform_identifier": "0xe624d70a34842c712747a543d080a49fee330fa1",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-10-23T02:30:39.948754Z",
+          "updated_at": "2024-05-03T10:25:48.775284Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1773187883486679040",
+          "profile_id": "43678",
+          "platform": "github",
+          "platform_identifier": "12707960",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/12707960?v=4",
+            "username": "zlatanpham"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-28T03:18:30.318305Z",
+          "updated_at": "2024-03-28T03:18:30.318305Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702639863033_avatar_790170208228212766.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "Web ❤️-er. Building interactive things.",
+      "name": "Thanh Pham",
+      "twitter_username": "_zlatanpham",
+      "discord_id": "790170208228212766",
+      "discord_username": "thanh.pham",
+      "github_username": "zlatanpham",
+      "github_url": "https://github.com/zlatanpham",
+      "github": {
+        "id": 12707960,
+        "login": "zlatanpham",
+        "avatar_url": "https://avatars.githubusercontent.com/u/12707960?v=4",
+        "name": "Thanh Pham",
+        "bio": "Web ❤️-er. Building interactive things.",
+        "twitter_username": "_zlatanpham",
+        "html_url": "https://github.com/zlatanpham"
+      }
+    },
+    "nguyend-nam": {
+      "id": "69586735",
+      "bio": "Frontend Engineer",
+      "avatar": "https://avatars.githubusercontent.com/u/69586735?v=4",
+      "websiteLink": "https://ngdnam.netlify.app/",
+      "name": "Nam Nguyen Dinh",
+      "github_username": "nguyend-nam",
+      "github_url": "https://github.com/nguyend-nam",
+      "github": {
+        "id": 69586735,
+        "login": "nguyend-nam",
+        "avatar_url": "https://avatars.githubusercontent.com/u/69586735?v=4",
+        "name": "Nam Nguyen Dinh",
+        "bio": "Frontend Engineer",
+        "html_url": "https://github.com/nguyend-nam",
+        "blog": "https://ngdnam.netlify.app/"
+      }
+    },
+    "maniub102": {
+      "id": "108899436",
+      "avatar": "https://avatars.githubusercontent.com/u/108899436?v=4",
+      "name": "nambui",
+      "github_username": "Maniub102",
+      "github_url": "https://github.com/Maniub102",
+      "github": {
+        "id": 108899436,
+        "login": "Maniub102",
+        "avatar_url": "https://avatars.githubusercontent.com/u/108899436?v=4",
+        "name": "nambui",
+        "html_url": "https://github.com/Maniub102"
+      }
+    },
+    "tuanddd": {
+      "id": "48438",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2025-02-05T08:12:40.605344Z",
+      "associated_accounts": [
+        {
+          "id": "48438",
+          "profile_id": "48438",
+          "platform": "discord",
+          "platform_identifier": "463379262620041226",
+          "platform_metadata": {
+            "username": "vincent.console"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:25.785378Z",
+          "updated_at": "2025-04-25T12:54:11.240964Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1704391908488384512",
+          "profile_id": "48438",
+          "platform": "telegram",
+          "platform_identifier": "1025539063",
+          "platform_metadata": {
+            "username": "daotuan"
+          },
+          "discord_id": "",
+          "created_at": "2023-09-20T07:07:51.711891Z",
+          "updated_at": "2025-02-05T08:12:44.713359Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1681548626297360384",
+          "profile_id": "48438",
+          "platform": "evm-chain",
+          "platform_identifier": "0x6497b5580a58f2b890b3ad66bc459341312acc23",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "daotuan.bnb",
+            "ens": "daotuan.eth"
+          },
+          "discord_id": "",
+          "created_at": "2023-07-19T06:16:48.829785Z",
+          "updated_at": "2024-04-23T03:23:50.983427Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772474649947410432",
+          "profile_id": "48438",
+          "platform": "github",
+          "platform_identifier": "25856620",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/25856620?v=4",
+            "username": "tuanddd"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:04:22.191555Z",
+          "updated_at": "2024-03-26T04:04:22.191555Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1640829359130415104",
+          "profile_id": "48438",
+          "platform": "solana-chain",
+          "platform_identifier": "EXw6jSPwiimT9tqsX7ckL31w3RJHG7wczzGfjJnzUTqD",
+          "platform_metadata": {
+            "sns": "daotuan.sol"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-28T21:32:59.009234Z",
+          "updated_at": "2024-03-14T07:59:02.9489Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1713767824863793152",
+          "profile_id": "48438",
+          "platform": "evm-chain",
+          "platform_identifier": "0x89e8160f7e71b31fff2481eda9a790d41a768f65",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-10-16T04:04:24.371191Z",
+          "updated_at": "2024-02-09T03:37:28.305148Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1643506211108163584",
+          "profile_id": "48438",
+          "platform": "evm-chain",
+          "platform_identifier": "0xe73c1cca40afed5f2eb1f710e66d22013667607e",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-04-05T06:49:50.254726Z",
+          "updated_at": "2024-01-22T11:01:09.273133Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1637523771323584512",
+          "profile_id": "48438",
+          "platform": "evm-chain",
+          "platform_identifier": "0xA3760a4dEf21F568286ceEf2886af891657F1997",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-19T18:37:45.461744Z",
+          "updated_at": "2024-01-22T11:01:07.414424Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1637525275627491328",
+          "profile_id": "48438",
+          "platform": "evm-chain",
+          "platform_identifier": "0x6D5264ABcC3FA9fB45526ceAEdF09155d0e6E443",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-19T18:43:44.11518Z",
+          "updated_at": "2024-01-22T11:01:05.541979Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1675723273230356480",
+          "profile_id": "48438",
+          "platform": "sui-chain",
+          "platform_identifier": "0x33c60dcb1d6373e24d8da300557c19ec94093f29200e5720e9dddee55d17792c",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-07-03T04:28:56.428272Z",
+          "updated_at": "2023-07-06T06:32:33.815517Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1676841145834934272",
+          "profile_id": "48438",
+          "platform": "ronin-chain",
+          "platform_identifier": "ronin:6657c2f246d98505cd64eba404b06a28353b343a",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-07-06T06:30:58.026562Z",
+          "updated_at": "2023-07-06T06:30:58.026562Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1637524523991437312",
+          "profile_id": "48438",
+          "platform": "solana-chain",
+          "platform_identifier": "9hqLU8DxbKZzb86XM7LL9gCVrzK8jDEBMgYHpHTwMUSp",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-19T18:40:44.911707Z",
+          "updated_at": "2023-04-04T14:35:09.855679Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1637524288095391744",
+          "profile_id": "48438",
+          "platform": "solana-chain",
+          "platform_identifier": "H7fQ9nWqYBRh57HY7LSE3uFVGPTNzvz33SJxUwWPSV2v",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-19T18:39:48.669538Z",
+          "updated_at": "2023-04-04T09:07:19.493601Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702648235775_avatar_463379262620041226.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 9885,
+      "application_id": null,
+      "application": null,
+      "name": "TuanD",
+      "discord_id": "463379262620041226",
+      "discord_username": "vincent.console",
+      "github_username": "tuanddd",
+      "github_url": "https://github.com/tuanddd",
+      "github": {
+        "id": 25856620,
+        "login": "tuanddd",
+        "avatar_url": "https://avatars.githubusercontent.com/u/25856620?v=4",
+        "name": "TuanD",
+        "html_url": "https://github.com/tuanddd"
+      }
+    },
+    "tonible14012002": {
+      "id": "1660548172054794240",
+      "created_at": "2023-05-22T07:28:30.368322Z",
+      "updated_at": "2023-12-15T03:32:30.50782Z",
+      "associated_accounts": [
+        {
+          "id": "1660548172058988544",
+          "profile_id": "1660548172054794240",
+          "platform": "discord",
+          "platform_identifier": "1100704516011216938",
+          "platform_metadata": {
+            "username": "namanh14mn"
+          },
+          "discord_id": "",
+          "created_at": "2023-05-22T07:28:30.369375Z",
+          "updated_at": "2024-12-16T23:07:25.429748Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1787303556701753344",
+          "profile_id": "1660548172054794240",
+          "platform": "evm-chain",
+          "platform_identifier": "0x0640e1a8f3df802d34f2335d089b8050b886fdae",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-05-06T02:09:09.069242Z",
+          "updated_at": "2024-05-06T02:09:09.069242Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1787302768172601344",
+          "profile_id": "1660548172054794240",
+          "platform": "github",
+          "platform_identifier": "88917321",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/88917321?v=4",
+            "username": "tonible14012002"
+          },
+          "discord_id": "",
+          "created_at": "2024-05-06T02:06:01.069268Z",
+          "updated_at": "2024-05-06T02:06:01.069268Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702611149849_avatar_1100704516011216938.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "websiteLink": "https://www.facebook.com/namanh.bui.549/",
+      "name": "Bui Ngoc Nam Anh",
+      "discord_id": "1100704516011216938",
+      "discord_username": "namanh14mn",
+      "github_username": "tonible14012002",
+      "github_url": "https://github.com/tonible14012002",
+      "github": {
+        "id": 88917321,
+        "login": "tonible14012002",
+        "avatar_url": "https://avatars.githubusercontent.com/u/88917321?v=4",
+        "name": "Bui Ngoc Nam Anh",
+        "html_url": "https://github.com/tonible14012002",
+        "blog": "https://www.facebook.com/namanh.bui.549/"
+      }
+    },
+    "huygn": {
+      "id": "10569203",
+      "avatar": "https://avatars.githubusercontent.com/u/10569203?v=4",
+      "name": "Huy Giang",
+      "twitter_username": "_huygn",
+      "github_username": "huygn",
+      "github_url": "https://github.com/huygn",
+      "github": {
+        "id": 10569203,
+        "login": "huygn",
+        "avatar_url": "https://avatars.githubusercontent.com/u/10569203?v=4",
+        "name": "Huy Giang",
+        "twitter_username": "_huygn",
+        "html_url": "https://github.com/huygn"
+      }
+    },
+    "dudaka": {
+      "id": "52263",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-03-13T08:02:26.18089Z",
+      "associated_accounts": [
+        {
+          "id": "1798631233706528768",
+          "profile_id": "52263",
+          "platform": "evm-chain",
+          "platform_identifier": "0xa26e471a4bfdf63cbd91e6b6b4145160c3514e64",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-06-06T08:21:17.725229Z",
+          "updated_at": "2024-06-06T08:21:17.725229Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1798629810705010688",
+          "profile_id": "52263",
+          "platform": "github",
+          "platform_identifier": "2733527",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/2733527?v=4",
+            "username": "dudaka"
+          },
+          "discord_id": "",
+          "created_at": "2024-06-06T08:15:38.455997Z",
+          "updated_at": "2024-06-06T08:15:38.455997Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "52263",
+          "profile_id": "52263",
+          "platform": "discord",
+          "platform_identifier": "282500790692741121",
+          "platform_metadata": {
+            "username": "dudaka"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:28.282482Z",
+          "updated_at": "2024-01-16T07:06:51.185033Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://cdn.discordapp.com/avatars/282500790692741121/f7d8a96e9d9e3a9dec614df77de39c76.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Dung Ho",
+      "discord_id": "282500790692741121",
+      "discord_username": "dudaka",
+      "github_username": "dudaka",
+      "github_url": "https://github.com/dudaka",
+      "github": {
+        "id": 2733527,
+        "login": "dudaka",
+        "avatar_url": "https://avatars.githubusercontent.com/u/2733527?v=4",
+        "name": "Dung Ho",
+        "html_url": "https://github.com/dudaka"
+      }
+    },
+    "namtrhg": {
+      "id": "63659165",
+      "bio": "Hi there 👋🏼",
+      "avatar": "https://avatars.githubusercontent.com/u/63659165?v=4",
+      "websiteLink": "https://www.tranhoangnam.net/",
+      "name": "Trần Hoàng Nam",
+      "github_username": "namtrhg",
+      "github_url": "https://github.com/namtrhg",
+      "github": {
+        "id": 63659165,
+        "login": "namtrhg",
+        "avatar_url": "https://avatars.githubusercontent.com/u/63659165?v=4",
+        "name": "Trần Hoàng Nam",
+        "bio": "Hi there 👋🏼",
+        "html_url": "https://github.com/namtrhg",
+        "blog": "https://www.tranhoangnam.net/"
+      }
+    },
+    "leduyhien152": {
+      "id": "44911",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T10:29:10.613725Z",
+      "associated_accounts": [
+        {
+          "id": "44911",
+          "profile_id": "44911",
+          "platform": "discord",
+          "platform_identifier": "861450611886522399",
+          "platform_metadata": {
+            "username": "hienld"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:23.874112Z",
+          "updated_at": "2025-04-25T09:35:08.827042Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1778624941508268032",
+          "profile_id": "44911",
+          "platform": "github",
+          "platform_identifier": "44285614",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/44285614?v=4",
+            "username": "leduyhien152"
+          },
+          "discord_id": "",
+          "created_at": "2024-04-12T03:23:25.966128Z",
+          "updated_at": "2024-04-12T03:23:25.966128Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1759896900225470464",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0x4fb57c09899a09f48f35eb12a555c48c516357cf",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-20T11:04:52.974884Z",
+          "updated_at": "2024-04-12T03:22:11.627605Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1763441202872455168",
+          "profile_id": "44911",
+          "platform": "solana-chain",
+          "platform_identifier": "9sppCnDU6QK1qpHXzdJFSZqR3GdKtMBuj6zM3zqCvcwY",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-03-01T05:48:40.575757Z",
+          "updated_at": "2024-03-01T05:48:40.575757Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1763440348983463936",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0x1342d156f7a74e78473f080d66474614e89d0dac",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-03-01T05:45:16.992259Z",
+          "updated_at": "2024-03-01T05:45:16.992259Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1762861615776010240",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0x95738c817b885bbdeeabab432a75aca1ec6e827c",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-28T15:25:36.243605Z",
+          "updated_at": "2024-03-01T05:44:42.087078Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1762861418886991872",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0xb5333020fdb9074b28fb93b8f9890ccdd6497279",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-28T15:24:49.301752Z",
+          "updated_at": "2024-02-28T15:24:49.301752Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1762859563020718080",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0x5e44ddc1785ee23ca1f5af49d5cfc24fc1f6afa4",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-28T15:17:26.82842Z",
+          "updated_at": "2024-02-28T15:20:07.533546Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1715379086597033984",
+          "profile_id": "44911",
+          "platform": "solana-chain",
+          "platform_identifier": "9NNFZuoDi3JxUT6nU696QH1gtPQaJ1GfoKMDNDqu2noy",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-10-20T14:46:59.104185Z",
+          "updated_at": "2024-02-28T15:16:57.342057Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1759896306949558272",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0x62b029bbcf78bc51254c1674dda350c1cebcc4de",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-20T11:02:31.526104Z",
+          "updated_at": "2024-02-20T11:02:31.526104Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1759893945531240448",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0xe38a99467c51132e41809bc706941344a95ec9b6",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-20T10:53:08.520049Z",
+          "updated_at": "2024-02-20T11:00:40.41455Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1743195464246759424",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0xec78a3b682877f19434126de851a6b14d32ebfc7",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2024-01-05T08:59:20.339086Z",
+          "updated_at": "2024-02-20T10:14:05.935164Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1715326751166435328",
+          "profile_id": "44911",
+          "platform": "evm-chain",
+          "platform_identifier": "0x30a58aeaaee383bc4259caa3772a7951454d90c5",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "1988stv.bnb",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-10-20T11:19:01.365439Z",
+          "updated_at": "2024-02-20T08:37:52.050968Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1752698461716746240",
+          "profile_id": "44911",
+          "platform": "binance",
+          "platform_identifier": "HpyKdiLrYT8yzfQJpy1PL8unNPzc1QM550MOZ0YJ5F2X1vwe5XPlhjPAyPTJshMQ",
+          "platform_metadata": {
+            "api_secret": "5yYFuiJfuO7sXFVfugFbLYcaOTRynwUQnGCk48a8tQAQIK8T1dbtHDqzSiOdb1jN"
+          },
+          "discord_id": "",
+          "created_at": "2024-01-31T14:20:51.49399Z",
+          "updated_at": "2024-01-31T14:20:51.49399Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702636150480_avatar_861450611886522399.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Hien Le",
+      "discord_id": "861450611886522399",
+      "discord_username": "hienld",
+      "github_username": "leduyhien152",
+      "github_url": "https://github.com/leduyhien152",
+      "github": {
+        "id": 44285614,
+        "login": "leduyhien152",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44285614?v=4",
+        "name": "Hien Le",
+        "html_url": "https://github.com/leduyhien152"
+      }
+    },
+    "thminhvn": {
+      "id": "33794",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2025-03-08T10:01:51.015862Z",
+      "associated_accounts": [
+        {
+          "id": "33794",
+          "profile_id": "33794",
+          "platform": "discord",
+          "platform_identifier": "564655945045770253",
+          "platform_metadata": {
+            "username": "minhth"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:17.826184Z",
+          "updated_at": "2025-05-02T02:19:50.750877Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1680838065750282240",
+          "profile_id": "33794",
+          "platform": "telegram",
+          "platform_identifier": "711425950",
+          "platform_metadata": {
+            "username": "gatetroy"
+          },
+          "discord_id": "",
+          "created_at": "2023-07-17T07:13:17.99389Z",
+          "updated_at": "2025-03-08T10:01:51.035262Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1773662407592251392",
+          "profile_id": "33794",
+          "platform": "github",
+          "platform_identifier": "11255278",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/11255278?v=4",
+            "username": "thminhVN"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T10:44:05.681381Z",
+          "updated_at": "2024-03-29T10:44:05.681381Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363064",
+          "profile_id": "33794",
+          "platform": "evm-chain",
+          "platform_identifier": "0x45b58ab9d398b3eeb8438b6591b216427964cbee",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": "gatetroy.eth"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-01-22T12:27:40.345933Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702642294992_avatar_564655945045770253.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 2559,
+      "application_id": null,
+      "application": null,
+      "name": "Minh Trần",
+      "discord_id": "564655945045770253",
+      "discord_username": "minhth",
+      "github_username": "thminhVN",
+      "github_url": "https://github.com/thminhVN",
+      "github": {
+        "id": 11255278,
+        "login": "thminhVN",
+        "avatar_url": "https://avatars.githubusercontent.com/u/11255278?v=4",
+        "name": "Minh Trần",
+        "html_url": "https://github.com/thminhVN"
+      }
+    },
+    "cnhhoang850": {
+      "id": "65607230",
+      "bio": "Always learning to code.",
+      "avatar": "https://avatars.githubusercontent.com/u/65607230?v=4",
+      "websiteLink": "https://adoring-goldstine-48b681.netlify.app/",
+      "name": "Cao Hoang",
+      "github_username": "cnhhoang850",
+      "github_url": "https://github.com/cnhhoang850",
+      "github": {
+        "id": 65607230,
+        "login": "cnhhoang850",
+        "avatar_url": "https://avatars.githubusercontent.com/u/65607230?v=4",
+        "name": "Cao Hoang",
+        "bio": "Always learning to code.",
+        "html_url": "https://github.com/cnhhoang850",
+        "blog": "https://adoring-goldstine-48b681.netlify.app/"
+      }
+    },
+    "hieuphq": {
+      "id": "13938010",
+      "avatar": "https://avatars.githubusercontent.com/u/13938010?v=4",
+      "name": "Phan Quang Hieu",
+      "github_username": "hieuphq",
+      "github_url": "https://github.com/hieuphq",
+      "github": {
+        "id": 13938010,
+        "login": "hieuphq",
+        "avatar_url": "https://avatars.githubusercontent.com/u/13938010?v=4",
+        "name": "Phan Quang Hieu",
+        "html_url": "https://github.com/hieuphq"
+      }
+    },
+    "chinhld12": {
+      "id": "34522",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T04:10:33.660602Z",
+      "associated_accounts": [
+        {
+          "id": "34522",
+          "profile_id": "34522",
+          "platform": "discord",
+          "platform_identifier": "757540075159420948",
+          "platform_metadata": {
+            "username": "chinhld"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:18.885157Z",
+          "updated_at": "2025-04-18T11:26:15.220362Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "360764",
+          "profile_id": "34522",
+          "platform": "evm-chain",
+          "platform_identifier": "0x053499083f0ed66a5af06245483faeeefc313249",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "chinhle.bnb",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:14.889373Z",
+          "updated_at": "2024-04-25T10:37:01.447739Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1774751363704557568",
+          "profile_id": "34522",
+          "platform": "solana-chain",
+          "platform_identifier": "6wPv3kPV3hN7UtGrUB2SpwRZVaL7PEwvJhsEBfj67FBt",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-04-01T10:51:13.050185Z",
+          "updated_at": "2024-04-12T03:12:20.551301Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1774734062108282880",
+          "profile_id": "34522",
+          "platform": "github",
+          "platform_identifier": "71743905",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/71743905?v=4",
+            "username": "chinhld12"
+          },
+          "discord_id": "",
+          "created_at": "2024-04-01T09:42:28.028594Z",
+          "updated_at": "2024-04-01T09:42:28.028594Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363094",
+          "profile_id": "34522",
+          "platform": "evm-chain",
+          "platform_identifier": "0x8ccb7107dbae4ee93d77b2c7fc4090179fe38979",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-01-22T12:29:34.414692Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1679676269639241728",
+          "profile_id": "34522",
+          "platform": "sui-chain",
+          "platform_identifier": "0x86558321c76a25f2eca4530bf331022e4692016431622443fb24ecbea49ebe8a",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-07-14T02:16:44.21574Z",
+          "updated_at": "2023-07-14T02:16:44.21574Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702613433537_avatar_757540075159420948.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Chinh Le",
+      "discord_id": "757540075159420948",
+      "discord_username": "chinhld",
+      "github_username": "chinhld12",
+      "github_url": "https://github.com/chinhld12",
+      "github": {
+        "id": 71743905,
+        "login": "chinhld12",
+        "avatar_url": "https://avatars.githubusercontent.com/u/71743905?v=4",
+        "name": "Chinh Le",
+        "html_url": "https://github.com/chinhld12"
+      }
+    },
+    "r-jim": {
+      "id": "33793",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-16T03:23:41.779293Z",
+      "associated_accounts": [
+        {
+          "id": "33793",
+          "profile_id": "33793",
+          "platform": "discord",
+          "platform_identifier": "336090238210408450",
+          "platform_metadata": {
+            "username": ".rjim"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:17.826184Z",
+          "updated_at": "2025-04-21T07:05:40.658019Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1778635244216258560",
+          "profile_id": "33793",
+          "platform": "evm-chain",
+          "platform_identifier": "0x893dcdbc90a4d0410a6ea6cb3abbdbc6b3b1a54d",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-04-12T04:04:22.323648Z",
+          "updated_at": "2024-04-12T04:04:22.323648Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1773663480004481024",
+          "profile_id": "33793",
+          "platform": "github",
+          "platform_identifier": "30451707",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/30451707?v=4",
+            "username": "R-Jim"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T10:48:21.364587Z",
+          "updated_at": "2024-03-29T10:48:21.364587Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702697021645_avatar_336090238210408450.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Cuong Mai (R Jim)",
+      "discord_id": "336090238210408450",
+      "discord_username": ".rjim",
+      "github_username": "R-Jim",
+      "github_url": "https://github.com/R-Jim",
+      "github": {
+        "id": 30451707,
+        "login": "R-Jim",
+        "avatar_url": "https://avatars.githubusercontent.com/u/30451707?v=4",
+        "name": "Cuong Mai (R Jim)",
+        "html_url": "https://github.com/R-Jim"
+      }
+    },
+    "taipham1803": {
+      "id": "24668",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T07:31:49.306732Z",
+      "associated_accounts": [
+        {
+          "id": "24668",
+          "profile_id": "24668",
+          "platform": "discord",
+          "platform_identifier": "419823988601257984",
+          "platform_metadata": {
+            "username": "taipn"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:13.511669Z",
+          "updated_at": "2025-04-21T02:04:27.414183Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363118",
+          "profile_id": "24668",
+          "platform": "evm-chain",
+          "platform_identifier": "0x9d6835a231473ee95cf95742b236c1ea40814460",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-04-15T03:33:05.908406Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772477363876007936",
+          "profile_id": "24668",
+          "platform": "github",
+          "platform_identifier": "23112684",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/23112684?v=4",
+            "username": "taipham1803"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:15:09.242343Z",
+          "updated_at": "2024-03-26T04:15:09.242343Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702625508939_avatar_419823988601257984.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "Software Engineer - Product enthusiast.\r\n",
+      "websiteLink": "taipn.vercel.app",
+      "name": "Harry",
+      "twitter_username": "heyry_pro",
+      "discord_id": "419823988601257984",
+      "discord_username": "taipn",
+      "github_username": "taipham1803",
+      "github_url": "https://github.com/taipham1803",
+      "github": {
+        "id": 23112684,
+        "login": "taipham1803",
+        "avatar_url": "https://avatars.githubusercontent.com/u/23112684?v=4",
+        "name": "Harry",
+        "bio": "Software Engineer - Product enthusiast.\r\n",
+        "twitter_username": "heyry_pro",
+        "html_url": "https://github.com/taipham1803",
+        "blog": "taipn.vercel.app"
+      }
+    },
+    "tieubao": {
+      "id": "40409",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2025-02-21T02:20:44.942762Z",
+      "associated_accounts": [
+        {
+          "id": "40409",
+          "profile_id": "40409",
+          "platform": "discord",
+          "platform_identifier": "151497832853929986",
+          "platform_metadata": {
+            "username": "baddeed"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:21.781603Z",
+          "updated_at": "2025-05-02T07:03:07.545891Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1679003308208951296",
+          "profile_id": "40409",
+          "platform": "telegram",
+          "platform_identifier": "498428856",
+          "platform_metadata": {
+            "username": "nntruonghan"
+          },
+          "discord_id": "",
+          "created_at": "2023-07-12T05:42:37.707137Z",
+          "updated_at": "2025-02-21T02:20:44.974746Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772475531208429568",
+          "profile_id": "40409",
+          "platform": "github",
+          "platform_identifier": "1749624",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/1749624?v=4",
+            "username": "tieubao"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:07:52.301005Z",
+          "updated_at": "2024-03-26T04:07:52.301005Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1660954629791289350",
+          "profile_id": "40409",
+          "platform": "solana-chain",
+          "platform_identifier": "3jg3NBSnUsYAZwxRYMEsfhVZdNwjLhJW1kpEYv58gfqU",
+          "platform_metadata": {
+            "sns": "d3gen.sol"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.723406Z",
+          "updated_at": "2024-01-26T20:58:56.366437Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "362926",
+          "profile_id": "40409",
+          "platform": "evm-chain",
+          "platform_identifier": "0xf3940eb383853d364f82b76f5d513fef73b06e0f",
+          "platform_metadata": {
+            "ans": "baddeed.arb",
+            "bns": "baddeed.bnb",
+            "ens": "baddeed.eth"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.723406Z",
+          "updated_at": "2024-01-22T11:00:55.085801Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1667152084945866752",
+          "profile_id": "40409",
+          "platform": "binance",
+          "platform_identifier": "9koXQQ4H7HtPLhVrmz79kJIakul9xDpxQe7ukaIDvU085WfPRlmOafHgqymTMQuG",
+          "platform_metadata": {
+            "api_secret": "XTmA4Vxlx5vMYwmphN93p1vcG49iNd8aYtUQkMg7wJr6a4WqJv5VfbmZzI1kGhJk",
+            "username": "nntruonghan"
+          },
+          "discord_id": "",
+          "created_at": "2023-06-09T12:50:05.896394Z",
+          "updated_at": "2023-06-09T12:50:05.896394Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1660954629791289346",
+          "profile_id": "40409",
+          "platform": "ronin-chain",
+          "platform_identifier": "ronin:cc3c0902c0ec5d6683654a8caeba734dbd4b8241",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-06-05T02:44:41.649327Z",
+          "updated_at": "2023-06-05T02:44:41.649327Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1660954629791289348",
+          "profile_id": "40409",
+          "platform": "aptos-chain",
+          "platform_identifier": "0x105a58d66e1157c7839c87766aba88f059170dabacd33fcd771e5dcc6c862f22",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.723406Z",
+          "updated_at": "2023-03-15T09:12:15.723406Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1660954629791289345",
+          "profile_id": "40409",
+          "platform": "near-chain",
+          "platform_identifier": "nntruonghan.near",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.723406Z",
+          "updated_at": "2023-03-15T09:12:15.723406Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1660954629791289347",
+          "profile_id": "40409",
+          "platform": "sui-chain",
+          "platform_identifier": "0x3e68b908ce8f9b6858c5ebffde4f09f72a593ba539556f8a5eb4eb0326dcd1e7",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.723406Z",
+          "updated_at": "2023-03-15T09:12:15.723406Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702689817615_avatar_151497832853929986.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 5542,
+      "application_id": null,
+      "application": null,
+      "bio": "Founder of @dwarvesf. \r\nBuilding @consolelabs and @webuild-community.",
+      "websiteLink": "https://han.ws",
+      "name": "Han Ngo",
+      "twitter_username": "nntruonghan",
+      "discord_id": "151497832853929986",
+      "discord_username": "baddeed",
+      "github_username": "tieubao",
+      "github_url": "https://github.com/tieubao",
+      "github": {
+        "id": 1749624,
+        "login": "tieubao",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1749624?v=4",
+        "name": "Han Ngo",
+        "bio": "Founder of @dwarvesf. \r\nBuilding @consolelabs and @webuild-community.",
+        "twitter_username": "nntruonghan",
+        "html_url": "https://github.com/tieubao",
+        "blog": "https://han.ws"
+      }
+    },
+    "minhluuquang": {
+      "id": "17746278",
+      "avatar": "https://avatars.githubusercontent.com/u/17746278?v=4",
+      "name": "minhlq",
+      "github_username": "minhluuquang",
+      "github_url": "https://github.com/minhluuquang",
+      "github": {
+        "id": 17746278,
+        "login": "minhluuquang",
+        "avatar_url": "https://avatars.githubusercontent.com/u/17746278?v=4",
+        "name": "minhlq",
+        "html_url": "https://github.com/minhluuquang"
+      }
+    },
+    "fuatto": {
+      "id": "17435002",
+      "avatar": "https://avatars.githubusercontent.com/u/17435002?v=4",
+      "websiteLink": "https://github.com/fuatto",
+      "name": "Phat Nguyen",
+      "twitter_username": "fuatto134",
+      "github_username": "fuatto",
+      "github_url": "https://github.com/fuatto",
+      "github": {
+        "id": 17435002,
+        "login": "fuatto",
+        "avatar_url": "https://avatars.githubusercontent.com/u/17435002?v=4",
+        "name": "Phat Nguyen",
+        "twitter_username": "fuatto134",
+        "html_url": "https://github.com/fuatto",
+        "blog": "https://github.com/fuatto"
+      }
+    },
+    "vdhieu": {
+      "id": "43686",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T10:49:46.138359Z",
+      "associated_accounts": [
+        {
+          "id": "43686",
+          "profile_id": "43686",
+          "platform": "discord",
+          "platform_identifier": "797044001579597846",
+          "platform_metadata": {
+            "username": "hieuvd"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:23.382025Z",
+          "updated_at": "2025-04-27T18:24:59.949677Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1722279763839553536",
+          "profile_id": "43686",
+          "platform": "evm-chain",
+          "platform_identifier": "0x3a7fe9d072d1174ae38407b09470b2dae6a33df1",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-11-08T15:47:48.767497Z",
+          "updated_at": "2024-04-12T03:03:44.525174Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772479543026651136",
+          "profile_id": "43686",
+          "platform": "github",
+          "platform_identifier": "12120998",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/12120998?v=4",
+            "username": "vdhieu"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:23:48.792793Z",
+          "updated_at": "2024-03-26T04:23:48.792793Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "360449",
+          "profile_id": "43686",
+          "platform": "evm-chain",
+          "platform_identifier": "0x42bfe8592b69c897452ffb9b74577aa80f836ed3",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:14.703413Z",
+          "updated_at": "2024-01-22T11:16:44.730034Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702637386009_avatar_797044001579597846.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Hieu Vu",
+      "discord_id": "797044001579597846",
+      "discord_username": "hieuvd",
+      "github_username": "vdhieu",
+      "github_url": "https://github.com/vdhieu",
+      "github": {
+        "id": 12120998,
+        "login": "vdhieu",
+        "avatar_url": "https://avatars.githubusercontent.com/u/12120998?v=4",
+        "name": "Hieu Vu",
+        "html_url": "https://github.com/vdhieu"
+      }
+    },
+    "anhnh12": {
+      "id": "34529672",
+      "avatar": "https://avatars.githubusercontent.com/u/34529672?v=4",
+      "github_username": "anhnh12",
+      "github_url": "https://github.com/anhnh12",
+      "github": {
+        "id": 34529672,
+        "login": "anhnh12",
+        "avatar_url": "https://avatars.githubusercontent.com/u/34529672?v=4",
+        "html_url": "https://github.com/anhnh12"
+      }
+    },
+    "thecodister": {
+      "id": "117727037",
+      "bio": "I'm a frontend software engineer. My goal is to become a full-stack developer in the future ",
+      "avatar": "https://avatars.githubusercontent.com/u/117727037?v=4",
+      "name": "Nguyễn Ngọc Quang",
+      "github_username": "TheCodister",
+      "github_url": "https://github.com/TheCodister",
+      "github": {
+        "id": 117727037,
+        "login": "TheCodister",
+        "avatar_url": "https://avatars.githubusercontent.com/u/117727037?v=4",
+        "name": "Nguyễn Ngọc Quang",
+        "bio": "I'm a frontend software engineer. My goal is to become a full-stack developer in the future ",
+        "html_url": "https://github.com/TheCodister"
+      }
+    },
+    "baenv": {
+      "id": "1640552476807532544",
+      "created_at": "2023-03-28T03:12:45.119281Z",
+      "updated_at": "2023-12-25T07:58:41.920835Z",
+      "associated_accounts": [
+        {
+          "id": "1640552476811726848",
+          "profile_id": "1640552476807532544",
+          "platform": "discord",
+          "platform_identifier": "421992793582469130",
+          "platform_metadata": {
+            "username": "bievh"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-28T03:12:45.120114Z",
+          "updated_at": "2025-04-29T06:43:46.906973Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1762778029475500032",
+          "profile_id": "1640552476807532544",
+          "platform": "evm-chain",
+          "platform_identifier": "0x5566729916110d1a9bd6c247cc676bdb6fc247be",
+          "platform_metadata": {
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2024-02-28T09:53:27.716134Z",
+          "updated_at": "2024-04-25T09:44:39.01571Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772474775231270912",
+          "profile_id": "1640552476807532544",
+          "platform": "github",
+          "platform_identifier": "32956772",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/32956772?v=4",
+            "username": "baenv"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:04:52.06191Z",
+          "updated_at": "2024-03-26T04:04:52.06191Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1645323373317722112",
+          "profile_id": "1640552476807532544",
+          "platform": "evm-chain",
+          "platform_identifier": "0x5155b007d5c1afe88912e52fabda1c7ed86baae0",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-04-10T07:10:35.486136Z",
+          "updated_at": "2024-01-22T12:45:56.183269Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1669539931724189696",
+          "profile_id": "1640552476807532544",
+          "platform": "evm-chain",
+          "platform_identifier": "0x46020f4f7d00069de34646e3123c68445b2034dc",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-06-16T02:58:32.932399Z",
+          "updated_at": "2024-01-22T12:45:54.336547Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1702569435073613824",
+          "profile_id": "1640552476807532544",
+          "platform": "evm-chain",
+          "platform_identifier": "0xf971cbb920d340c94900295972d0d470d8dafb72",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-09-15T06:26:00.189689Z",
+          "updated_at": "2024-01-22T12:45:52.494944Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1707298361838669824",
+          "profile_id": "1640552476807532544",
+          "platform": "evm-chain",
+          "platform_identifier": "0x158deb1dda52d51b5b1e56428450e8b6a222c89f",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-09-28T07:37:04.189421Z",
+          "updated_at": "2024-01-22T12:45:05.170846Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1669545271752658944",
+          "profile_id": "1640552476807532544",
+          "platform": "evm-chain",
+          "platform_identifier": "0x9ca6cb970e317548853d15c384d075dec97004aa",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-06-16T03:19:46.094625Z",
+          "updated_at": "2024-01-22T12:44:57.779063Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702696494724_avatar_421992793582469130.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 100,
+      "application_id": null,
+      "application": null,
+      "bio": "Don't worry, Im here",
+      "name": "bean",
+      "discord_id": "421992793582469130",
+      "discord_username": "bievh",
+      "github_username": "baenv",
+      "github_url": "https://github.com/baenv",
+      "github": {
+        "id": 32956772,
+        "login": "baenv",
+        "avatar_url": "https://avatars.githubusercontent.com/u/32956772?v=4",
+        "name": "bean",
+        "bio": "Don't worry, Im here",
+        "html_url": "https://github.com/baenv"
+      }
+    },
+    "haongo138": {
+      "id": "52516",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T09:44:25.832378Z",
+      "associated_accounts": [
+        {
+          "id": "52516",
+          "profile_id": "52516",
+          "platform": "discord",
+          "platform_identifier": "490895538892439553",
+          "platform_metadata": {
+            "username": "haongo1"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:28.629942Z",
+          "updated_at": "2025-04-22T03:34:11.203853Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1778620788425887744",
+          "profile_id": "52516",
+          "platform": "evm-chain",
+          "platform_identifier": "0x5742543b29100592c5d8b5f7a1be6ca61b65b034",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-04-12T03:06:55.794266Z",
+          "updated_at": "2024-04-12T03:08:13.357234Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772474621166096384",
+          "profile_id": "52516",
+          "platform": "github",
+          "platform_identifier": "27359472",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/27359472?v=4",
+            "username": "haongo138"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:04:15.32995Z",
+          "updated_at": "2024-03-26T04:04:15.32995Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363139",
+          "profile_id": "52516",
+          "platform": "evm-chain",
+          "platform_identifier": "0xe409e073ee7474c381bfd9b3f8809849941b5870",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-01-22T12:57:55.597211Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "360011",
+          "profile_id": "52516",
+          "platform": "evm-chain",
+          "platform_identifier": "0x60cbffe7980738b08d9c1661cc75d0e068074cb1",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:14.541432Z",
+          "updated_at": "2024-01-22T11:02:31.066119Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702633465484_avatar_490895538892439553.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "born to solve any problems .",
+      "name": "haongo",
+      "twitter_username": "metaagold",
+      "discord_id": "490895538892439553",
+      "discord_username": "haongo1",
+      "github_username": "haongo138",
+      "github_url": "https://github.com/haongo138",
+      "github": {
+        "id": 27359472,
+        "login": "haongo138",
+        "avatar_url": "https://avatars.githubusercontent.com/u/27359472?v=4",
+        "name": "haongo",
+        "bio": "born to solve any problems .",
+        "twitter_username": "metaagold",
+        "html_url": "https://github.com/haongo138"
+      }
+    },
+    "jack": {
+      "id": "85945244",
+      "bio": "U2FsdGVkX1+WrzGgSa8TvrsBqfXmFzMC81RAGXfvlqnMrUT2gVmAsxcbTz04Hpb4",
+      "avatar": "https://avatars.githubusercontent.com/u/85945244?v=4",
+      "github_username": "jack",
+      "github_url": "https://github.com/jack",
+      "github": {
+        "id": 85945244,
+        "login": "jack",
+        "avatar_url": "https://avatars.githubusercontent.com/u/85945244?v=4",
+        "bio": "U2FsdGVkX1+WrzGgSa8TvrsBqfXmFzMC81RAGXfvlqnMrUT2gVmAsxcbTz04Hpb4",
+        "html_url": "https://github.com/jack"
+      }
+    },
+    "datnguyennnx": {
+      "id": "52270",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-11-18T05:04:22.485015Z",
+      "associated_accounts": [
+        {
+          "id": "52270",
+          "profile_id": "52270",
+          "platform": "discord",
+          "platform_identifier": "396307229986521098",
+          "platform_metadata": {
+            "username": "datnguyennnx"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:28.372303Z",
+          "updated_at": "2025-05-01T05:30:01.393894Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1816061391883210752",
+          "profile_id": "52270",
+          "platform": "evm-chain",
+          "platform_identifier": "0x0e02cfeb2021ae0cea5cb6afac40356131074fd3",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-07-24T10:42:31.271283Z",
+          "updated_at": "2024-07-24T10:42:31.271283Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772493978332041216",
+          "profile_id": "52270",
+          "platform": "evm-chain",
+          "platform_identifier": "0x67797fda002f15250799e7866a202a91dbbc6caf",
+          "platform_metadata": {
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T05:21:10.437027Z",
+          "updated_at": "2024-05-06T04:46:10.584217Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1787338073357422592",
+          "profile_id": "52270",
+          "platform": "binance",
+          "platform_identifier": "chPG0KgMPlGR08gJ1tFS7iZ130fVDvYs7cCpdEz3305uGoFwNWR2vZ7RZaaS4nvJ",
+          "platform_metadata": {
+            "api_secret": "sEgNMEj68jHrMEsIi8ziA8afbHuh8a4VpY6ocDjTLR1C5L9dpFc1a5pN67P2YPKf"
+          },
+          "discord_id": "",
+          "created_at": "2024-05-06T04:26:18.481628Z",
+          "updated_at": "2024-05-06T04:26:18.481628Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772475519162388480",
+          "profile_id": "52270",
+          "platform": "github",
+          "platform_identifier": "73730153",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/73730153?v=4",
+            "username": "datnguyennnx"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:07:49.428056Z",
+          "updated_at": "2024-03-26T04:07:49.428056Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1700283862007_avatar_396307229986521098.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "Technical problems are solvable with knowledge of how it works.",
+      "name": "Nguyen Dat",
+      "discord_id": "396307229986521098",
+      "discord_username": "datnguyennnx",
+      "github_username": "datnguyennnx",
+      "github_url": "https://github.com/datnguyennnx",
+      "github": {
+        "id": 73730153,
+        "login": "datnguyennnx",
+        "avatar_url": "https://avatars.githubusercontent.com/u/73730153?v=4",
+        "name": "Nguyen Dat",
+        "bio": "Technical problems are solvable with knowledge of how it works.",
+        "html_url": "https://github.com/datnguyennnx"
+      }
+    },
+    "thanhpn": {
+      "id": "1097783",
+      "bio": "💬 Senior Full-stack and Blockchain Engineering",
+      "avatar": "https://avatars.githubusercontent.com/u/1097783?v=4",
+      "name": "Pham Thanh",
+      "github_username": "thanhpn",
+      "github_url": "https://github.com/thanhpn",
+      "github": {
+        "id": 1097783,
+        "login": "thanhpn",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1097783?v=4",
+        "name": "Pham Thanh",
+        "bio": "💬 Senior Full-stack and Blockchain Engineering",
+        "html_url": "https://github.com/thanhpn"
+      }
+    },
+    "duynglam": {
+      "id": "45552896",
+      "avatar": "https://avatars.githubusercontent.com/u/45552896?v=4",
+      "websiteLink": "www.duynglam.com",
+      "name": "Duy",
+      "twitter_username": "duynglam",
+      "github_username": "duynglam",
+      "github_url": "https://github.com/duynglam",
+      "github": {
+        "id": 45552896,
+        "login": "duynglam",
+        "avatar_url": "https://avatars.githubusercontent.com/u/45552896?v=4",
+        "name": "Duy",
+        "twitter_username": "duynglam",
+        "html_url": "https://github.com/duynglam",
+        "blog": "www.duynglam.com"
+      }
+    },
+    "grok": {
+      "id": "495761",
+      "bio": "I'm an avid student of Stuff and Things.",
+      "avatar": "https://avatars.githubusercontent.com/u/495761?v=4",
+      "websiteLink": "https://sterlinghamilton.com/",
+      "name": "Sterling Hamilton",
+      "twitter_username": "sterlo",
+      "github_username": "grok",
+      "github_url": "https://github.com/grok",
+      "github": {
+        "id": 495761,
+        "login": "grok",
+        "avatar_url": "https://avatars.githubusercontent.com/u/495761?v=4",
+        "name": "Sterling Hamilton",
+        "bio": "I'm an avid student of Stuff and Things.",
+        "twitter_username": "sterlo",
+        "html_url": "https://github.com/grok",
+        "blog": "https://sterlinghamilton.com/"
+      }
+    },
+    "hthai2201": {
+      "id": "48635",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-14T09:27:32.070833Z",
+      "associated_accounts": [
+        {
+          "id": "48635",
+          "profile_id": "48635",
+          "platform": "discord",
+          "platform_identifier": "831098577635377162",
+          "platform_metadata": {
+            "username": "hthai2201"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:25.965872Z",
+          "updated_at": "2025-04-29T02:07:03.167471Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "362551",
+          "profile_id": "48635",
+          "platform": "evm-chain",
+          "platform_identifier": "0xc53136e3b9bafcbf7c671fe35a5e1a16b76bfb5c",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "lukez.bnb",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.594316Z",
+          "updated_at": "2024-04-12T04:16:27.695865Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1773661231018676224",
+          "profile_id": "48635",
+          "platform": "github",
+          "platform_identifier": "56551188",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/56551188?v=4",
+            "username": "hthai2201"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T10:39:25.164555Z",
+          "updated_at": "2024-03-29T10:39:25.164555Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702546052011_avatar_831098577635377162.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "discord_id": "831098577635377162",
+      "discord_username": "hthai2201",
+      "github_username": "hthai2201",
+      "github_url": "https://github.com/hthai2201",
+      "github": {
+        "id": 56551188,
+        "login": "hthai2201",
+        "avatar_url": "https://avatars.githubusercontent.com/u/56551188?v=4",
+        "html_url": "https://github.com/hthai2201"
+      }
+    },
+    "longbuivan": {
+      "id": "1768520836290973696",
+      "created_at": "2024-03-15T06:13:19.557245Z",
+      "updated_at": "2024-03-15T06:13:19.557245Z",
+      "associated_accounts": [
+        {
+          "id": "1768520836290973696",
+          "profile_id": "1768520836290973696",
+          "platform": "discord",
+          "platform_identifier": "1157659003527106630",
+          "platform_metadata": {
+            "username": "longbuivan"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-15T06:13:19.557963Z",
+          "updated_at": "2024-05-17T11:45:42.176197Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772474671384498176",
+          "profile_id": "1768520836290973696",
+          "platform": "github",
+          "platform_identifier": "45690915",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/45690915?v=4",
+            "username": "longbuivan"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:04:27.302134Z",
+          "updated_at": "2024-03-26T04:04:27.302134Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1771723824165818368",
+          "profile_id": "1768520836290973696",
+          "platform": "binance",
+          "platform_identifier": "yPFiv9F9Jlks8FCYzMwMbH0InsMLzErFPbqMsF0Db4zqSvi8XOFolInHQR1febQk",
+          "platform_metadata": {
+            "api_secret": "KesyFzQTinPllgm26DMGHD0lOeup61vgN0tWuqJB16lkd9HtmNO9UgkKvr9tuWRE"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-24T02:20:51.375823Z",
+          "updated_at": "2024-03-24T02:20:51.375823Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1771719455575904256",
+          "profile_id": "1768520836290973696",
+          "platform": "evm-chain",
+          "platform_identifier": "0x0bf3eea95008d8a5b92ed4d85a76fd70755e180a",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-03-24T02:03:29.82227Z",
+          "updated_at": "2024-03-24T02:11:58.254038Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://cdn.discordapp.com/avatars/1157659003527106630/211766094de8ebfa08e49216f0710d5a.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "Connecting Data x Platform.",
+      "websiteLink": "https://longdatadevlog.com",
+      "name": "Long Bui",
+      "twitter_username": "longdatadevlog",
+      "discord_id": "1157659003527106630",
+      "discord_username": "longbuivan",
+      "github_username": "longbuivan",
+      "github_url": "https://github.com/longbuivan",
+      "github": {
+        "id": 45690915,
+        "login": "longbuivan",
+        "avatar_url": "https://avatars.githubusercontent.com/u/45690915?v=4",
+        "name": "Long Bui",
+        "bio": "Connecting Data x Platform.",
+        "twitter_username": "longdatadevlog",
+        "html_url": "https://github.com/longbuivan",
+        "blog": "https://longdatadevlog.com"
+      }
+    },
+    "minhcloud": {
+      "id": "55834",
+      "created_at": "2023-03-13T08:22:33.682537Z",
+      "updated_at": "2024-07-01T11:19:28.815875Z",
+      "associated_accounts": [
+        {
+          "id": "55834",
+          "profile_id": "55834",
+          "platform": "discord",
+          "platform_identifier": "1007496699511570503",
+          "platform_metadata": {
+            "username": "minh_cloud"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:30.113517Z",
+          "updated_at": "2025-04-15T10:28:26.926573Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1695015962413109248",
+          "profile_id": "55834",
+          "platform": "telegram",
+          "platform_identifier": "1953427979",
+          "platform_metadata": {
+            "username": "Minh_cloud"
+          },
+          "discord_id": "",
+          "created_at": "2023-08-25T10:11:11.970898Z",
+          "updated_at": "2024-07-01T11:19:28.833874Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363137",
+          "profile_id": "55834",
+          "platform": "evm-chain",
+          "platform_identifier": "0x70c5d7f4ea7f7a3065fe146bf5683a8b31777af9",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-05-03T08:58:22.100942Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772821522432397312",
+          "profile_id": "55834",
+          "platform": "github",
+          "platform_identifier": "126894784",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/126894784?v=4",
+            "username": "minhcloud"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-27T03:02:43.037005Z",
+          "updated_at": "2024-03-27T03:02:43.037005Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1678991386155683840",
+          "profile_id": "55834",
+          "platform": "evm-chain",
+          "platform_identifier": "0x9d9275d14ff7bc2cb698e273be8bac934a506f9a",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-07-12T04:55:15.268672Z",
+          "updated_at": "2024-03-06T01:50:09.261094Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1636667516849754112",
+          "profile_id": "55834",
+          "platform": "evm-chain",
+          "platform_identifier": "0xD1405121E3f3b7FF8ceCDFd524A78A8142344f2a",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-17T09:55:18.486365Z",
+          "updated_at": "2024-01-22T12:40:05.200058Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "363345",
+          "profile_id": "55834",
+          "platform": "evm-chain",
+          "platform_identifier": "0xf246b6385dc7df4d0191fb21aa5c9de91b99f501",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.930334Z",
+          "updated_at": "2024-01-22T12:35:04.280839Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1749323116187750400",
+          "profile_id": "55834",
+          "platform": "binance",
+          "platform_identifier": "uB8Pj1HtEyfDaW7jKzyto1SHOoALOz5Q5myXnuCw21h0uNGOGD4nkI3RsbxG6QAb",
+          "platform_metadata": {
+            "api_secret": "d3xTOU4nTvWgs3CkqurraRi4pkfr6IKyrn6FzDVkZenSIYaLxdRoZmiAlZkI0Rj3"
+          },
+          "discord_id": "",
+          "created_at": "2024-01-22T06:48:26.408588Z",
+          "updated_at": "2024-01-22T06:48:26.408588Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "155834",
+          "profile_id": "55834",
+          "platform": "solana-chain",
+          "platform_identifier": "GM2qZkEu3zAZ2hYKrjYuYsc5416kfrdbJa1TdhgWnx34",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:30.113517Z",
+          "updated_at": "2023-10-06T06:43:39.368295Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702641662185_avatar_1007496699511570503.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 5118,
+      "application_id": null,
+      "application": null,
+      "name": "minhcloud",
+      "discord_id": "1007496699511570503",
+      "discord_username": "minh_cloud",
+      "github_username": "minhcloud",
+      "github_url": "https://github.com/minhcloud",
+      "github": {
+        "id": 126894784,
+        "login": "minhcloud",
+        "avatar_url": "https://avatars.githubusercontent.com/u/126894784?v=4",
+        "name": "minhcloud",
+        "html_url": "https://github.com/minhcloud"
+      }
+    },
+    "toanbku": {
+      "id": "34618",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-09T02:27:00.244102Z",
+      "associated_accounts": [
+        {
+          "id": "34618",
+          "profile_id": "34618",
+          "platform": "discord",
+          "platform_identifier": "526053379080716298",
+          "platform_metadata": {
+            "username": "toanhq"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:18.885157Z",
+          "updated_at": "2025-03-13T09:11:27.042458Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1816634788488941568",
+          "profile_id": "34618",
+          "platform": "github",
+          "platform_identifier": "28706996",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/28706996?v=4",
+            "username": "toanbku"
+          },
+          "discord_id": "",
+          "created_at": "2024-07-26T00:40:59.675284Z",
+          "updated_at": "2024-07-26T00:40:59.675284Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363123",
+          "profile_id": "34618",
+          "platform": "evm-chain",
+          "platform_identifier": "0xe4eb4bbcb01247638f7d7d664f7b771f406a411a",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-01-22T12:43:00.609275Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702088819800_avatar_526053379080716298.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Toan Ho",
+      "discord_id": "526053379080716298",
+      "discord_username": "toanhq",
+      "github_username": "toanbku",
+      "github_url": "https://github.com/toanbku",
+      "github": {
+        "id": 28706996,
+        "login": "toanbku",
+        "avatar_url": "https://avatars.githubusercontent.com/u/28706996?v=4",
+        "name": "Toan Ho",
+        "html_url": "https://github.com/toanbku"
+      }
+    },
+    "huynguyenh": {
+      "id": "43418",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2025-01-13T11:19:34.71672Z",
+      "associated_accounts": [
+        {
+          "id": "43418",
+          "profile_id": "43418",
+          "platform": "discord",
+          "platform_identifier": "567326528216760320",
+          "platform_metadata": {
+            "username": ".hnh"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:23.082116Z",
+          "updated_at": "2025-04-18T17:10:52.54556Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1679012518640488448",
+          "profile_id": "43418",
+          "platform": "telegram",
+          "platform_identifier": "925939899",
+          "platform_metadata": {
+            "username": "huynguyenh"
+          },
+          "discord_id": "",
+          "created_at": "2023-07-12T06:19:13.645492Z",
+          "updated_at": "2025-01-13T11:19:34.730766Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "359945",
+          "profile_id": "43418",
+          "platform": "evm-chain",
+          "platform_identifier": "0x8d565bd9596ac3d1e8662bd5661085b95a5d4f99",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": "huynguyenh.eth"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:14.541432Z",
+          "updated_at": "2024-04-12T02:54:08.233084Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1770437231442399232",
+          "profile_id": "43418",
+          "platform": "github",
+          "platform_identifier": "23558573",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/23558573?v=4",
+            "username": "huynguyenh"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-20T13:08:23.766202Z",
+          "updated_at": "2024-03-20T13:08:23.766202Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1760497702656806912",
+          "profile_id": "43418",
+          "platform": "evm-chain",
+          "platform_identifier": "0xf6354dd1b7c38304c689e76b92d702e34bcec188",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-02-22T02:52:15.436573Z",
+          "updated_at": "2024-02-22T02:52:15.436573Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1677947120725790720",
+          "profile_id": "43418",
+          "platform": "evm-chain",
+          "platform_identifier": "0x28d037ff33cef7195f49c56e02b6b5f8b7370136",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-07-09T07:45:42.988743Z",
+          "updated_at": "2024-01-22T11:00:59.667809Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1669586344881426432",
+          "profile_id": "43418",
+          "platform": "binance",
+          "platform_identifier": "YmOdgUqH6p0nA5f31A8mi0xwp85gdOlzaJNgfIRcBiZaPYGqe3ovfjXtMIYVlVKm",
+          "platform_metadata": {
+            "api_secret": "THmC5ZF3AQu2G6jnHw8KblN8mgKI45vD14H3eBNG22YeKxFMnSCQUUC0cefa6KUs"
+          },
+          "discord_id": "",
+          "created_at": "2023-06-16T06:02:58.691346Z",
+          "updated_at": "2023-06-16T06:02:58.691346Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1635919982049103972",
+          "profile_id": "43418",
+          "platform": "solana-chain",
+          "platform_identifier": "5nFJhhXhBwSaEkih4BSBcfCDXSfpr6WK9HAN2WxoZiYb",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-03-15T08:24:52.301117Z",
+          "updated_at": "2023-03-15T08:24:52.301117Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "hnh",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702696919881_avatar_567326528216760320.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 12494,
+      "application_id": null,
+      "application": null,
+      "name": "hnh",
+      "discord_id": "567326528216760320",
+      "discord_username": ".hnh",
+      "github_username": "huynguyenh",
+      "github_url": "https://github.com/huynguyenh",
+      "github": {
+        "id": 23558573,
+        "login": "huynguyenh",
+        "avatar_url": "https://avatars.githubusercontent.com/u/23558573?v=4",
+        "name": "hnh",
+        "html_url": "https://github.com/huynguyenh"
+      }
+    },
+    "lmquang": {
+      "id": "43210",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T02:38:05.242172Z",
+      "associated_accounts": [
+        {
+          "id": "43210",
+          "profile_id": "43210",
+          "platform": "discord",
+          "platform_identifier": "686038111217909809",
+          "platform_metadata": {
+            "username": "ics3rd"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:22.985329Z",
+          "updated_at": "2025-05-02T02:19:50.458266Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772478687917117440",
+          "profile_id": "43210",
+          "platform": "github",
+          "platform_identifier": "7887262",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/7887262?v=4",
+            "username": "lmquang"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:20:24.918048Z",
+          "updated_at": "2024-03-26T04:20:24.918048Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1671413673156939776",
+          "profile_id": "43210",
+          "platform": "evm-chain",
+          "platform_identifier": "0x14e28cb74c5ba7241eecbcae642a0426f2fa1fbc",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-06-21T07:04:07.702891Z",
+          "updated_at": "2024-01-22T12:45:30.796276Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "360416",
+          "profile_id": "43210",
+          "platform": "evm-chain",
+          "platform_identifier": "0x26fcb7b62013617b42fcc04049dd188d1191858e",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:14.703413Z",
+          "updated_at": "2024-01-22T12:42:58.772182Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702607885141_avatar_686038111217909809.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "devops",
+      "name": "Quang Le",
+      "discord_id": "686038111217909809",
+      "discord_username": "ics3rd",
+      "github_username": "lmquang",
+      "github_url": "https://github.com/lmquang",
+      "github": {
+        "id": 7887262,
+        "login": "lmquang",
+        "avatar_url": "https://avatars.githubusercontent.com/u/7887262?v=4",
+        "name": "Quang Le",
+        "bio": "devops",
+        "html_url": "https://github.com/lmquang"
+      }
+    },
+    "ooohminh": {
+      "id": "80204839",
+      "avatar": "https://avatars.githubusercontent.com/u/80204839?v=4",
+      "name": "minh",
+      "github_username": "ooohminh",
+      "github_url": "https://github.com/ooohminh",
+      "github": {
+        "id": 80204839,
+        "login": "ooohminh",
+        "avatar_url": "https://avatars.githubusercontent.com/u/80204839?v=4",
+        "name": "minh",
+        "html_url": "https://github.com/ooohminh"
+      }
+    },
+    "datphamcode295": {
+      "id": "572",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-14T15:51:43.073916Z",
+      "associated_accounts": [
+        {
+          "id": "572",
+          "profile_id": "572",
+          "platform": "discord",
+          "platform_identifier": "817336393751330864",
+          "platform_metadata": {
+            "username": "datpv"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:22:59.185583Z",
+          "updated_at": "2025-04-14T04:05:50.275625Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1787305110833991680",
+          "profile_id": "572",
+          "platform": "evm-chain",
+          "platform_identifier": "0x6bf95509704b42ee3ecaf7159694921fea867f0d",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-05-06T02:15:19.603119Z",
+          "updated_at": "2024-05-06T02:15:19.603119Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772474607706574848",
+          "profile_id": "572",
+          "platform": "github",
+          "platform_identifier": "55711201",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/55711201?v=4",
+            "username": "datphamcode295"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:04:12.120555Z",
+          "updated_at": "2024-03-26T04:04:12.120555Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702569102597_avatar_817336393751330864.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Pham Dat",
+      "discord_id": "817336393751330864",
+      "discord_username": "datpv",
+      "github_username": "datphamcode295",
+      "github_url": "https://github.com/datphamcode295",
+      "github": {
+        "id": 55711201,
+        "login": "datphamcode295",
+        "avatar_url": "https://avatars.githubusercontent.com/u/55711201?v=4",
+        "name": "Pham Dat",
+        "html_url": "https://github.com/datphamcode295"
+      }
+    },
+    "namtran": {
+      "id": "2252658",
+      "avatar": "https://avatars.githubusercontent.com/u/2252658?v=4",
+      "name": "NamTran",
+      "github_username": "namtran",
+      "github_url": "https://github.com/namtran",
+      "github": {
+        "id": 2252658,
+        "login": "namtran",
+        "avatar_url": "https://avatars.githubusercontent.com/u/2252658?v=4",
+        "name": "NamTran",
+        "html_url": "https://github.com/namtran"
+      }
+    },
+    "nnhuyhoang": {
+      "id": "71623092",
+      "avatar": "https://avatars.githubusercontent.com/u/71623092?v=4",
+      "github_username": "nnhuyhoang",
+      "github_url": "https://github.com/nnhuyhoang",
+      "github": {
+        "id": 71623092,
+        "login": "nnhuyhoang",
+        "avatar_url": "https://avatars.githubusercontent.com/u/71623092?v=4",
+        "html_url": "https://github.com/nnhuyhoang"
+      }
+    },
+    "taynguyen": {
+      "id": "53934",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-14T07:05:41.633717Z",
+      "associated_accounts": [
+        {
+          "id": "53934",
+          "profile_id": "53934",
+          "platform": "discord",
+          "platform_identifier": "794443008824049695",
+          "platform_metadata": {
+            "username": "taynguyen88"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:29.221057Z",
+          "updated_at": "2024-08-26T08:11:27.629988Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1648357752377970688",
+          "profile_id": "53934",
+          "platform": "evm-chain",
+          "platform_identifier": "0x6dff822aa18fcb88d9e8ebdea099341ba111e606",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-04-18T16:08:07.830184Z",
+          "updated_at": "2024-05-04T14:55:26.346255Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1778621227783426048",
+          "profile_id": "53934",
+          "platform": "evm-chain",
+          "platform_identifier": "0x60008a3100fcffefb3f8ed6809c7cf8004eb2ae4",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-04-12T03:08:40.545911Z",
+          "updated_at": "2024-04-12T03:08:40.545911Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1773662434335133696",
+          "profile_id": "53934",
+          "platform": "github",
+          "platform_identifier": "3897652",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/3897652?v=4",
+            "username": "taynguyen"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T10:44:12.057845Z",
+          "updated_at": "2024-03-29T10:44:12.057845Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702537540954_avatar_794443008824049695.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "Tay Nguyen",
+      "discord_id": "794443008824049695",
+      "discord_username": "taynguyen88",
+      "github_username": "taynguyen",
+      "github_url": "https://github.com/taynguyen",
+      "github": {
+        "id": 3897652,
+        "login": "taynguyen",
+        "avatar_url": "https://avatars.githubusercontent.com/u/3897652?v=4",
+        "name": "Tay Nguyen",
+        "html_url": "https://github.com/taynguyen"
+      }
+    },
+    "tienan92it": {
+      "id": "45733",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-13T10:51:48.884546Z",
+      "associated_accounts": [
+        {
+          "id": "45733",
+          "profile_id": "45733",
+          "platform": "discord",
+          "platform_identifier": "874125795549909082",
+          "platform_metadata": {
+            "username": "cor3.co"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:24.340463Z",
+          "updated_at": "2025-04-13T06:15:43.686629Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1773662637008097280",
+          "profile_id": "45733",
+          "platform": "github",
+          "platform_identifier": "11957056",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/11957056?v=4",
+            "username": "tienan92it"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T10:45:00.378149Z",
+          "updated_at": "2024-03-29T10:45:00.378149Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1654351455336796160",
+          "profile_id": "45733",
+          "platform": "evm-chain",
+          "platform_identifier": "0xddceb8cbe89dae45de5578d2cbf75ecfe064a90f",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "cor3x.bnb",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-05-05T05:04:57.97323Z",
+          "updated_at": "2024-01-22T12:50:44.703635Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1668154555948339200",
+          "profile_id": "45733",
+          "platform": "binance",
+          "platform_identifier": "P8UgWqsOJIAgBSCsYPHxnB14e3sr2A9mN9HYTe5o9DY3b7ykz3ke6EAfygOHb4Rv",
+          "platform_metadata": {
+            "api_secret": "WideD9mRrlWOjrfSEMaxa7N4PDSTRPJl7wzov6FdqblFcGt2eszXZkkCNwu6nTiq"
+          },
+          "discord_id": "",
+          "created_at": "2023-06-12T07:13:33.608217Z",
+          "updated_at": "2023-06-12T07:13:33.608217Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702464708783_avatar_874125795549909082.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "Coffee Lover",
+      "name": "An Tran",
+      "discord_id": "874125795549909082",
+      "discord_username": "cor3.co",
+      "github_username": "tienan92it",
+      "github_url": "https://github.com/tienan92it",
+      "github": {
+        "id": 11957056,
+        "login": "tienan92it",
+        "avatar_url": "https://avatars.githubusercontent.com/u/11957056?v=4",
+        "name": "An Tran",
+        "bio": "Coffee Lover",
+        "html_url": "https://github.com/tienan92it"
+      }
+    },
+    "thangnt294": {
+      "id": "40182",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-14T09:18:14.624809Z",
+      "associated_accounts": [
+        {
+          "id": "40182",
+          "profile_id": "40182",
+          "platform": "discord",
+          "platform_identifier": "985564092934807632",
+          "platform_metadata": {
+            "username": "thomas294"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:21.724319Z",
+          "updated_at": "2025-04-10T10:01:53.840482Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1783437726503145472",
+          "profile_id": "40182",
+          "platform": "evm-chain",
+          "platform_identifier": "0x92ce8af3f081f45dc010083afe4d2bd53b32331c",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2024-04-25T10:07:43.32675Z",
+          "updated_at": "2024-04-25T10:07:43.32675Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772476618074230784",
+          "profile_id": "40182",
+          "platform": "github",
+          "platform_identifier": "51191083",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/51191083?v=4",
+            "username": "thangnt294"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:12:11.429885Z",
+          "updated_at": "2024-03-26T04:12:11.429885Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702545494300_avatar_985564092934807632.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "Not a very good programmer",
+      "name": "Thomas Nguyen",
+      "discord_id": "985564092934807632",
+      "discord_username": "thomas294",
+      "github_username": "thangnt294",
+      "github_url": "https://github.com/thangnt294",
+      "github": {
+        "id": 51191083,
+        "login": "thangnt294",
+        "avatar_url": "https://avatars.githubusercontent.com/u/51191083?v=4",
+        "name": "Thomas Nguyen",
+        "bio": "Not a very good programmer",
+        "html_url": "https://github.com/thangnt294"
+      }
+    },
+    "bringastar": {
+      "id": "50713",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T11:00:36.580525Z",
+      "associated_accounts": [
+        {
+          "id": "50713",
+          "profile_id": "50713",
+          "platform": "discord",
+          "platform_identifier": "575525326181105674",
+          "platform_metadata": {
+            "username": "anna.console"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:27.685473Z",
+          "updated_at": "2025-03-20T03:53:00.932451Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1773585948487979008",
+          "profile_id": "50713",
+          "platform": "github",
+          "platform_identifier": "67300946",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/67300946?v=4",
+            "username": "bringastar"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T05:40:16.410025Z",
+          "updated_at": "2024-03-29T05:40:16.410025Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1638510276598829056",
+          "profile_id": "50713",
+          "platform": "evm-chain",
+          "platform_identifier": "0xb6637b8ef61592efd243751119fe8056caa1ed87",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-22T11:57:46.647274Z",
+          "updated_at": "2024-02-22T08:40:29.887911Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "360303",
+          "profile_id": "50713",
+          "platform": "evm-chain",
+          "platform_identifier": "0x65730857372602e9a98227cd25d4588c325ca216",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:14.703413Z",
+          "updated_at": "2024-01-22T11:13:01.510826Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1683411156460376064",
+          "profile_id": "50713",
+          "platform": "binance",
+          "platform_identifier": "fOLKNq9EpDEU1ti59jkXt6ZcQtyUiG9ZHaEXVul2ndcOTyaAxPena7QqMBA4mBUY",
+          "platform_metadata": {
+            "api_secret": "beoXj1gVNpkgV6Zv29bJAPdmWIohe7LvVI3SClT7BFQvXDL7jYJBoBUW1LFyD5QJ"
+          },
+          "discord_id": "",
+          "created_at": "2023-07-24T09:37:50.624371Z",
+          "updated_at": "2023-07-24T09:37:50.624371Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702638036487_avatar_575525326181105674.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "name": "anna",
+      "discord_id": "575525326181105674",
+      "discord_username": "anna.console",
+      "github_username": "bringastar",
+      "github_url": "https://github.com/bringastar",
+      "github": {
+        "id": 67300946,
+        "login": "bringastar",
+        "avatar_url": "https://avatars.githubusercontent.com/u/67300946?v=4",
+        "name": "anna",
+        "html_url": "https://github.com/bringastar"
+      }
+    },
+    "huytieu": {
+      "id": "43000",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2025-05-03T11:42:40.314191Z",
+      "associated_accounts": [
+        {
+          "id": "1695016157704097792",
+          "profile_id": "43000",
+          "platform": "telegram",
+          "platform_identifier": "826739389",
+          "platform_metadata": {
+            "username": "Light_Huy_Tieu"
+          },
+          "discord_id": "",
+          "created_at": "2023-08-25T10:11:58.53184Z",
+          "updated_at": "2025-05-03T11:42:40.324783Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "43000",
+          "profile_id": "43000",
+          "platform": "discord",
+          "platform_identifier": "361172853326086144",
+          "platform_metadata": {
+            "username": "0xlight"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:22.897588Z",
+          "updated_at": "2025-03-04T08:01:06.517496Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772506571511697408",
+          "profile_id": "43000",
+          "platform": "github",
+          "platform_identifier": "10217502",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/10217502?v=4",
+            "username": "huytieu"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T06:11:12.88513Z",
+          "updated_at": "2024-03-26T06:11:12.88513Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "361095",
+          "profile_id": "43000",
+          "platform": "evm-chain",
+          "platform_identifier": "0x15fd47744d29973ca1f2bad8ee07f54a550e6fd4",
+          "platform_metadata": {
+            "ans": "0xlight.arb",
+            "bns": "0xlight.bnb",
+            "ens": "tqhuy.eth"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.031975Z",
+          "updated_at": "2024-01-22T11:00:57.802073Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1678627445151895552",
+          "profile_id": "43000",
+          "platform": "sui-chain",
+          "platform_identifier": "0xa7ccd74d273d28cfe3d44f091cf5cd61a48a898dc9798df9475412801f961c16",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-07-11T04:49:04.97107Z",
+          "updated_at": "2023-07-11T04:49:04.97107Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1674680724839469056",
+          "profile_id": "43000",
+          "platform": "binance",
+          "platform_identifier": "8xU03MLqrtLFaMOCHwPeGYF66C5rU57pnBeSKjz9aAFeiqWHLaWY1sZvVwuJgzYT",
+          "platform_metadata": {
+            "api_secret": "ZG3GOZuU8ktZHgywkW3Bx37MsMJf9ubzgvZGCVNjH48sIkYT7lzl9s3AFwyHbJT0"
+          },
+          "discord_id": "",
+          "created_at": "2023-06-30T07:26:13.522943Z",
+          "updated_at": "2023-06-30T07:26:13.522943Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702656189976_avatar_361172853326086144.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 2266,
+      "application_id": null,
+      "application": null,
+      "name": "Huy Tieu",
+      "discord_id": "361172853326086144",
+      "discord_username": "0xlight",
+      "github_username": "huytieu",
+      "github_url": "https://github.com/huytieu",
+      "github": {
+        "id": 10217502,
+        "login": "huytieu",
+        "avatar_url": "https://avatars.githubusercontent.com/u/10217502?v=4",
+        "name": "Huy Tieu",
+        "html_url": "https://github.com/huytieu"
+      }
+    },
+    "nikkingtr": {
+      "id": "55138",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T13:46:28.690485Z",
+      "associated_accounts": [
+        {
+          "id": "55138",
+          "profile_id": "55138",
+          "platform": "discord",
+          "platform_identifier": "796991130184187944",
+          "platform_metadata": {
+            "username": "nikkingtr"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:29.699099Z",
+          "updated_at": "2025-03-20T03:42:09.014569Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1773662476894736384",
+          "profile_id": "55138",
+          "platform": "github",
+          "platform_identifier": "150410266",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/150410266?v=4",
+            "username": "nikkingtr"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-29T10:44:22.204316Z",
+          "updated_at": "2024-03-29T10:44:22.204316Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "362488",
+          "profile_id": "55138",
+          "platform": "evm-chain",
+          "platform_identifier": "0xbd65f487db80c0c292c2d334a19d56ecb8feb28d",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.594316Z",
+          "updated_at": "2024-01-22T12:10:40.071979Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702647988558_avatar_796991130184187944.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "discord_id": "796991130184187944",
+      "discord_username": "nikkingtr",
+      "github_username": "nikkingtr",
+      "github_url": "https://github.com/nikkingtr",
+      "github": {
+        "id": 150410266,
+        "login": "nikkingtr",
+        "avatar_url": "https://avatars.githubusercontent.com/u/150410266?v=4",
+        "html_url": "https://github.com/nikkingtr"
+      }
+    },
+    "ngolapnguyen": {
+      "id": "52455",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T16:11:36.456554Z",
+      "associated_accounts": [
+        {
+          "id": "52455",
+          "profile_id": "52455",
+          "platform": "discord",
+          "platform_identifier": "397044011883429908",
+          "platform_metadata": {
+            "username": "mashiro5951"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:28.372303Z",
+          "updated_at": "2025-04-18T11:03:12.187124Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772483797548273664",
+          "profile_id": "52455",
+          "platform": "github",
+          "platform_identifier": "11691985",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/11691985?v=4",
+            "username": "ngolapnguyen"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:40:43.149292Z",
+          "updated_at": "2024-03-26T04:40:43.149292Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363130",
+          "profile_id": "52455",
+          "platform": "evm-chain",
+          "platform_identifier": "0x102bd3474afdb897badcb5aceab46364dfe1014a",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-01-22T12:29:36.265149Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702656696376_avatar_397044011883429908.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "A lazy soul who wants to create.",
+      "websiteLink": "ngolapnguyen.com",
+      "name": "Ngo Lap Nguyen",
+      "discord_id": "397044011883429908",
+      "discord_username": "mashiro5951",
+      "github_username": "ngolapnguyen",
+      "github_url": "https://github.com/ngolapnguyen",
+      "github": {
+        "id": 11691985,
+        "login": "ngolapnguyen",
+        "avatar_url": "https://avatars.githubusercontent.com/u/11691985?v=4",
+        "name": "Ngo Lap Nguyen",
+        "bio": "A lazy soul who wants to create.",
+        "html_url": "https://github.com/ngolapnguyen",
+        "blog": "ngolapnguyen.com"
+      }
+    },
+    "thanhlmm": {
+      "id": "9281080",
+      "bio": "Software Engineer who loves making high-standard products.\r\n\r\nFounder @getnimbus",
+      "avatar": "https://avatars.githubusercontent.com/u/9281080?v=4",
+      "websiteLink": "https://thanhle.blog",
+      "name": "Thanh Le",
+      "twitter_username": "thanhledev",
+      "github_username": "thanhlmm",
+      "github_url": "https://github.com/thanhlmm",
+      "github": {
+        "id": 9281080,
+        "login": "thanhlmm",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9281080?v=4",
+        "name": "Thanh Le",
+        "bio": "Software Engineer who loves making high-standard products.\r\n\r\nFounder @getnimbus",
+        "twitter_username": "thanhledev",
+        "html_url": "https://github.com/thanhlmm",
+        "blog": "https://thanhle.blog"
+      }
+    },
+    "monotykamary": {
+      "id": "45639",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T10:48:39.357271Z",
+      "associated_accounts": [
+        {
+          "id": "45639",
+          "profile_id": "45639",
+          "platform": "discord",
+          "platform_identifier": "184354519726030850",
+          "platform_metadata": {
+            "username": "monotykamary"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:24.340463Z",
+          "updated_at": "2025-04-30T16:03:34.389703Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "363058",
+          "profile_id": "45639",
+          "platform": "evm-chain",
+          "platform_identifier": "0xfdfb16ffaf364a4ae15db843ae18a76fd848e79e",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-15T09:12:15.844091Z",
+          "updated_at": "2024-05-06T04:19:46.866998Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772478046901637120",
+          "profile_id": "45639",
+          "platform": "github",
+          "platform_identifier": "1130103",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/1130103?v=4",
+            "username": "monotykamary"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:17:52.088508Z",
+          "updated_at": "2024-03-26T04:17:52.088508Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702637319231_avatar_184354519726030850.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "discord_id": "184354519726030850",
+      "discord_username": "monotykamary",
+      "github_username": "monotykamary",
+      "github_url": "https://github.com/monotykamary",
+      "github": {
+        "id": 1130103,
+        "login": "monotykamary",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1130103?v=4",
+        "html_url": "https://github.com/monotykamary"
+      }
+    },
+    "trankhacvy": {
+      "id": "8068926",
+      "bio": "Make Code Not War",
+      "avatar": "https://avatars.githubusercontent.com/u/8068926?v=4",
+      "websiteLink": "https://khacvy.substack.com/",
+      "name": "Khac Vy",
+      "twitter_username": "trankhac_vy",
+      "github_username": "trankhacvy",
+      "github_url": "https://github.com/trankhacvy",
+      "github": {
+        "id": 8068926,
+        "login": "trankhacvy",
+        "avatar_url": "https://avatars.githubusercontent.com/u/8068926?v=4",
+        "name": "Khac Vy",
+        "bio": "Make Code Not War",
+        "twitter_username": "trankhac_vy",
+        "html_url": "https://github.com/trankhacvy",
+        "blog": "https://khacvy.substack.com/"
+      }
+    },
+    "quanghuynguyen1902": {
+      "id": "44124",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2025-01-25T12:17:05.317216Z",
+      "associated_accounts": [
+        {
+          "id": "44124",
+          "profile_id": "44124",
+          "platform": "discord",
+          "platform_identifier": "861984704084181012",
+          "platform_metadata": {
+            "username": "huymaius"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:23.502456Z",
+          "updated_at": "2025-04-22T03:34:11.539754Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1706560563871485952",
+          "profile_id": "44124",
+          "platform": "telegram",
+          "platform_identifier": "2009456367",
+          "platform_metadata": {
+            "username": "huysol"
+          },
+          "discord_id": "",
+          "created_at": "2023-09-26T06:45:19.446473Z",
+          "updated_at": "2025-01-25T12:17:05.335987Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772821754733924352",
+          "profile_id": "44124",
+          "platform": "github",
+          "platform_identifier": "39359294",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/39359294?v=4",
+            "username": "quanghuynguyen1902"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-27T03:03:38.421866Z",
+          "updated_at": "2024-03-27T03:03:38.421866Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1679778750985670656",
+          "profile_id": "44124",
+          "platform": "evm-chain",
+          "platform_identifier": "0x818a993542e3a73baebd44eca835233a3e3470ef",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-07-14T09:03:57.672902Z",
+          "updated_at": "2024-01-22T12:45:32.642472Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1637030299223199744",
+          "profile_id": "44124",
+          "platform": "evm-chain",
+          "platform_identifier": "0x123B1E30e8A02f06EEaa37Ce563D5C89dB553EEb",
+          "platform_metadata": {
+            "ans": "",
+            "bns": "",
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2023-03-18T09:56:52.544289Z",
+          "updated_at": "2024-01-22T12:42:10.618249Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1675889317999808512",
+          "profile_id": "44124",
+          "platform": "sui-chain",
+          "platform_identifier": "0x0add85534fb981032549138ecb5d2566227b688b41ea2b64ad9f4316ddbe99e7",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-07-03T15:28:44.586757Z",
+          "updated_at": "2023-07-03T15:28:44.586757Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1675733261390712832",
+          "profile_id": "44124",
+          "platform": "sui-chain",
+          "platform_identifier": "0x736c30c8cb69aa4b440ebeebce035b9d5cc2d3b64e88703c8463ca82720a0829",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-07-03T05:08:37.791444Z",
+          "updated_at": "2023-07-03T07:06:53.630096Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1673974897535094784",
+          "profile_id": "44124",
+          "platform": "solana-chain",
+          "platform_identifier": "39AT13zf2twNfti99hFq49xrXgc1hocwsiMdSyGZtyUH",
+          "platform_metadata": {},
+          "discord_id": "",
+          "created_at": "2023-06-28T08:41:31.179433Z",
+          "updated_at": "2023-06-28T08:41:31.179433Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702642251916_avatar_861984704084181012.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 2722,
+      "application_id": null,
+      "application": null,
+      "name": "Huy Nguyen Quang",
+      "discord_id": "861984704084181012",
+      "discord_username": "huymaius",
+      "github_username": "quanghuynguyen1902",
+      "github_url": "https://github.com/quanghuynguyen1902",
+      "github": {
+        "id": 39359294,
+        "login": "quanghuynguyen1902",
+        "avatar_url": "https://avatars.githubusercontent.com/u/39359294?v=4",
+        "name": "Huy Nguyen Quang",
+        "html_url": "https://github.com/quanghuynguyen1902"
+      }
+    },
+    "innnotruong": {
+      "id": "38618",
+      "created_at": "2023-03-13T08:02:26.18089Z",
+      "updated_at": "2023-12-15T05:24:52.593611Z",
+      "associated_accounts": [
+        {
+          "id": "38618",
+          "profile_id": "38618",
+          "platform": "discord",
+          "platform_identifier": "753995829559165044",
+          "platform_metadata": {
+            "username": "innno_"
+          },
+          "discord_id": "",
+          "created_at": "2023-03-13T08:23:20.946949Z",
+          "updated_at": "2025-04-29T05:20:41.694245Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        },
+        {
+          "id": "1772475826214801408",
+          "profile_id": "38618",
+          "platform": "evm-chain",
+          "platform_identifier": "0xfe235c6de2d90db5ec5528456df934bfa7586caa",
+          "platform_metadata": {
+            "ens": ""
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:09:02.635214Z",
+          "updated_at": "2024-04-12T08:49:56.724684Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": true
+        },
+        {
+          "id": "1772474909734211584",
+          "profile_id": "38618",
+          "platform": "github",
+          "platform_identifier": "109653764",
+          "platform_metadata": {
+            "avatar": "https://avatars.githubusercontent.com/u/109653764?v=4",
+            "username": "innnotruong"
+          },
+          "discord_id": "",
+          "created_at": "2024-03-26T04:05:24.129944Z",
+          "updated_at": "2024-03-26T04:05:24.129944Z",
+          "total_amount": "",
+          "pnl": "",
+          "is_guild_member": false,
+          "is_wallet": false
+        }
+      ],
+      "associated_account_pendings": null,
+      "profile_name": "",
+      "avatar": "https://consolelabs-mochi-prod.s3.ap-southeast-1.amazonaws.com/applications/avatars/1702617892192_avatar_753995829559165044.png",
+      "pnl": "",
+      "type": "user",
+      "active_score": 0,
+      "application_id": null,
+      "application": null,
+      "bio": "learning how to write. i'm currently working as an executive assistant at Dwarves Foundation.",
+      "websiteLink": "https://memo.d.foundation/contributor/innnotruong/",
+      "name": "mytruong",
+      "discord_id": "753995829559165044",
+      "discord_username": "innno_",
+      "github_username": "innnotruong",
+      "github_url": "https://github.com/innnotruong",
+      "github": {
+        "id": 109653764,
+        "login": "innnotruong",
+        "avatar_url": "https://avatars.githubusercontent.com/u/109653764?v=4",
+        "name": "mytruong",
+        "bio": "learning how to write. i'm currently working as an executive assistant at Dwarves Foundation.",
+        "html_url": "https://github.com/innnotruong",
+        "blog": "https://memo.d.foundation/contributor/innnotruong/"
+      }
+    },
+    "tranthiaivi266": {
+      "id": "155152741",
+      "avatar": "https://avatars.githubusercontent.com/u/155152741?v=4",
+      "github_username": "tranthiaivi266",
+      "github_url": "https://github.com/tranthiaivi266",
+      "github": {
+        "id": 155152741,
+        "login": "tranthiaivi266",
+        "avatar_url": "https://avatars.githubusercontent.com/u/155152741?v=4",
+        "html_url": "https://github.com/tranthiaivi266"
+      }
+    }
+  },
+  "updated_at": "2025-05-12T12:14:00.383Z"
+}


### PR DESCRIPTION
This PR improves the `scripts/generate-user-profiles.ts` script by addressing GitHub API rate limits and optimizing profile fetching.

**Changes:**

- **Respect GitHub Rate Limits:** Implemented dynamic rate limit checking using `octokit.rest.rateLimit.get()` before fetching user data from the GitHub API. The script will now pause execution if the core rate limit is close to being exceeded, waiting for the reset time.
- **Skip Existing Profiles:** Modified the script to read the existing `public/content/userProfiles.json` file at the start. If a user profile already exists in this file with sufficient details (like an ID or avatar), the script will skip fetching the data for that user, reducing unnecessary API calls.
- **Maximum Wait Time:** Added a maximum threshold for how long the script will wait for the rate limit to reset (set to 30 seconds). If the calculated wait time exceeds this, the script will skip fetching GitHub data for that user to prevent excessively long build times in production environments.

These changes make the profile generation script more efficient, robust, and suitable for continuous integration environments.