### PR TITLE
feat: script get tree menu node sorted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ run:
 	@cd lib/obsidian-compiler && mix export_markdown
 	@cd lib/obsidian-compiler && mix duckdb.export
 	@pnpm run generate-menu
+	@pnpm run generate-menu-path-sorted
 	@pnpm run generate-backlinks
 	@pnpm run generate-search-index
 	@pnpm run generate-redirects-map

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "generate-backlinks": "tsx scripts/generate-backlinks.ts",
     "generate-summary": "tsx scripts/generate-summary.ts",
     "generate-user-profiles": "tsx scripts/generate-user-profiles.ts",
+    "generate-menu-path-sorted": "tsx scripts/generate-menu-path-sorted.ts",
     "copy-404": "cp out/404/index.html out/404.html"
   },
   "type": "module",
@@ -37,6 +38,7 @@
     "@rainbow-me/rainbowkit": "^2.2.4",
     "@tailwindcss/forms": "^0.5.10",
     "@tanstack/react-query": "^5.72.2",
+    "@types/glob": "^8.1.0",
     "@types/lodash": "^4.17.16",
     "acorn": "^8.14.1",
     "arweave": "^1.15.7",
@@ -48,6 +50,7 @@
     "draft-js": "^0.11.7",
     "ethers": "^6.13.5",
     "gh-pages": "^6.3.0",
+    "glob": "^11.0.2",
     "gray-matter": "^4.0.3",
     "hast-util-to-string": "^3.0.1",
     "html-react-parser": "^5.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.72.2
         version: 5.72.2(react@19.1.0)
+      '@types/glob':
+        specifier: ^8.1.0
+        version: 8.1.0
       '@types/lodash':
         specifier: ^4.17.16
         version: 4.17.16
@@ -83,6 +86,9 @@ importers:
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.2
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -744,6 +750,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
@@ -1607,6 +1617,9 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/glob@8.1.0':
+    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -1630,6 +1643,9 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/minimatch@5.1.2':
+    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -2791,6 +2807,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   eciesjs@0.4.14:
     resolution: {integrity: sha512-eJAgf9pdv214Hn98FlUzclRMYWF7WfoLlkS9nWMTm1qcCwn6Ad4EGD9lr9HXMBfSrZhYQujRE+p0adPRkctC6A==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -3259,6 +3278,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
@@ -3343,6 +3366,11 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@11.0.2:
+    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3713,6 +3741,10 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@4.1.0:
+    resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
+    engines: {node: 20 || >=22}
+
   jdenticon@3.3.0:
     resolution: {integrity: sha512-DhuBRNRIybGPeAjMjdHbkIfiwZCCmf8ggu7C49jhp6aJ7DYsZfudnvnTY5/1vgUhrGA7JaDAx1WevnpjCPvaGg==}
     engines: {node: '>=6.4.0'}
@@ -3968,6 +4000,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
   lucide-react@0.483.0:
     resolution: {integrity: sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==}
     peerDependencies:
@@ -4219,6 +4255,10 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -4228,6 +4268,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minisearch@7.1.2:
     resolution: {integrity: sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==}
@@ -4466,6 +4510,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -4500,6 +4547,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
@@ -5148,6 +5199,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -5752,6 +5807,14 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
@@ -6251,6 +6314,15 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.1':
     optional: true
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -7253,6 +7325,11 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/glob@8.1.0':
+    dependencies:
+      '@types/minimatch': 5.1.2
+      '@types/node': 20.17.28
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -7272,6 +7349,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
+
+  '@types/minimatch@5.1.2': {}
 
   '@types/minimist@1.2.5': {}
 
@@ -8808,6 +8887,8 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  eastasianwidth@0.2.0: {}
+
   eciesjs@0.4.14:
     dependencies:
       '@ecies/ciphers': 0.2.3(@noble/ciphers@1.2.1)
@@ -9500,6 +9581,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data-encoder@1.7.2: {}
 
   form-data@4.0.2:
@@ -9595,6 +9681,15 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
+
+  glob@11.0.2:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.0
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   globals@14.0.0: {}
 
@@ -10042,6 +10137,10 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@4.1.0:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jdenticon@3.3.0:
     dependencies:
       canvas-renderer: 2.2.1
@@ -10292,6 +10391,8 @@ snapshots:
       highlight.js: 11.11.1
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.1.0: {}
 
   lucide-react@0.483.0(react@19.1.0):
     dependencies:
@@ -10826,6 +10927,10 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -10835,6 +10940,8 @@ snapshots:
       brace-expansion: 2.0.1
 
   minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
 
   minisearch@7.1.2: {}
 
@@ -11102,6 +11209,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.10
@@ -11135,6 +11244,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
 
   path-to-regexp@8.2.0: {}
 
@@ -11882,6 +11996,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.4.0
@@ -12552,6 +12672,18 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   wrap-ansi@9.0.0:
     dependencies:

--- a/scripts/generate-menu-path-sorted.ts
+++ b/scripts/generate-menu-path-sorted.ts
@@ -253,7 +253,6 @@ async function processDirectoryRecursive(
         absolute: false,
         dot: true,
       });
-      console.log(baseDir, globConfigPath, configFiles);
       const configFile = configFiles[0];
       if (configFile) {
         const config = await parseConfig(path.join(baseDir, configFile));

--- a/scripts/generate-menu-path-sorted.ts
+++ b/scripts/generate-menu-path-sorted.ts
@@ -1,0 +1,351 @@
+import fs from 'fs/promises';
+import type { Stats } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { glob, type GlobOptions } from 'glob';
+
+// Create async glob function
+const globAsync = (
+  pattern: string,
+  options: GlobOptions = {},
+): Promise<string[]> =>
+  new Promise((resolve, reject) => {
+    glob(pattern, options)
+      .then(matches => resolve(matches.map(match => match.toString())))
+      .catch(err => reject(err));
+  });
+
+// Constants
+const VAULT_DIR = 'vault';
+const CONFIG_PATTERN = '**/.config.{yaml,yml}';
+const GLOB_MOC_FILE_PATTERN = '§*.md';
+const MOC_REGEX = /^\[§.*.md\]$/gi;
+const OUTPUT_FILE = 'public/content/menu-sorted.json';
+
+// Interfaces
+interface SortPatterns {
+  folders: string[];
+  file_patterns: string[];
+}
+
+interface FilePatterns {
+  sort?: string[];
+}
+
+interface NestedObject {
+  [key: string]: string | NestedObject;
+}
+
+/**
+ * Find all config files in the vault directory
+ */
+async function findConfigFiles(baseDir: string): Promise<string[]> {
+  try {
+    return await globAsync(CONFIG_PATTERN, {
+      cwd: baseDir,
+      absolute: false,
+      dot: true,
+    });
+  } catch (error) {
+    console.error('Error finding config files:', error);
+    return [];
+  }
+}
+
+/**
+ * Parse YAML config file
+ */
+async function parseConfig(filePath: string): Promise<FilePatterns | null> {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return yaml.load(content) as FilePatterns;
+  } catch (error) {
+    console.error(`Error parsing config file ${filePath}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Extract markdown links from MoC file content
+ */
+function extractMarkdownLinks(content: string): string[] {
+  const links: string[] = [];
+
+  // Match [[wiki-style]] links
+  const wikiPattern = /\[\[(.*?)\]\]/g;
+  let match;
+  while ((match = wikiPattern.exec(content)) !== null) {
+    if (match[1]) links.push(match[1]);
+  }
+
+  // Match [text](link.md) style links
+  const markdownPattern = /\[.*?\]\((.*?\.md)\)/g;
+  while ((match = markdownPattern.exec(content)) !== null) {
+    if (match[1]) {
+      // Remove .md extension and get basename
+      const basename = path.basename(match[1], '.md');
+      links.push(basename);
+    }
+  }
+
+  return [...new Set(links)]; // Remove duplicates
+}
+
+/**
+ * Process MoC files in a directory and extract ordered links
+ */
+async function processMoCFiles(
+  dirPath: string,
+  mocPatterns: string[],
+): Promise<string[]> {
+  try {
+    const mocFiles = await globAsync(GLOB_MOC_FILE_PATTERN, {
+      cwd: dirPath,
+      absolute: false,
+    });
+
+    let allLinks: string[] = [];
+    const mocFilesMatchingPattern = mocFiles.filter(file =>
+      mocPatterns.some(pattern => matchPattern(file, pattern)),
+    );
+    for (const mocFile of mocFilesMatchingPattern) {
+      const content = await fs.readFile(path.join(dirPath, mocFile), 'utf8');
+      allLinks = [...allLinks, ...extractMarkdownLinks(content)];
+    }
+
+    return allLinks;
+  } catch (error) {
+    console.error(`Error processing MoC files in ${dirPath}:`, error);
+    return [];
+  }
+}
+
+/**
+ * Match item against pattern
+ */
+function matchPattern(item: string, pattern: string): boolean {
+  const regex = new RegExp(`^${pattern.replace('*', '.*')}$`);
+  return regex.test(item);
+}
+
+/**
+ * Sort directories based on folder patterns
+ */
+function sortDirectories(
+  folders: string[],
+  folderPatterns: string[],
+): string[] {
+  const sortedFolders: string[] = [];
+  const remainingFolders = new Set(folders);
+
+  // First, sort by patterns
+  for (const pattern of folderPatterns) {
+    folders.forEach(folder => {
+      if (matchPattern(folder, pattern)) {
+        sortedFolders.push(folder);
+        remainingFolders.delete(folder);
+      }
+    });
+  }
+
+  // Add remaining folders alphabetically
+  sortedFolders.push(...Array.from(remainingFolders).sort());
+
+  return sortedFolders;
+}
+
+/**
+ * Sort markdown files based on patterns and MoC links
+ */
+function sortMarkdownFiles(
+  mdFiles: string[],
+  filePatterns: string[],
+  mocLinks: string[],
+): string[] {
+  if (!filePatterns.length && !mocLinks.length) {
+    return [];
+  }
+  const sortedFiles: string[] = [];
+  const remainingFiles = new Set(mdFiles);
+
+  // First, sort by patterns
+  for (const pattern of filePatterns) {
+    if (MOC_REGEX.test(pattern)) continue; // Skip MoC pattern
+
+    mdFiles.forEach(file => {
+      if (matchPattern(file, pattern)) {
+        sortedFiles.push(file);
+        remainingFiles.delete(file);
+      }
+    });
+  }
+
+  // Then, add files from MoC links
+  for (const link of mocLinks) {
+    const matchingFile = Array.from(remainingFiles).find(
+      file => path.basename(file, path.extname(file)) === link,
+    );
+    if (matchingFile) {
+      sortedFiles.push(matchingFile);
+      remainingFiles.delete(matchingFile);
+    }
+  }
+
+  // Finally, add remaining markdown files alphabetically
+  sortedFiles.push(...Array.from(remainingFiles).sort());
+
+  return sortedFiles;
+}
+
+function normalizePath(filePath: string): string {
+  // Removing path started with `vault/` and replacing backslashes with slashes
+  return filePath.replace(/^(vault\/|\\)/, '').replace(/\\/g, '/');
+}
+
+function getSortPatterns(config: FilePatterns | null): SortPatterns {
+  const sortPatterns: SortPatterns = {
+    folders: [],
+    file_patterns: [],
+  };
+  const sortConfig = (config?.sort || []).map((pattern: string) =>
+    String(pattern),
+  );
+  sortPatterns.folders =
+    sortConfig
+      .filter(p => p.startsWith('/'))
+      .map(p => p.replace(/^\//, '')) || [];
+  sortPatterns.file_patterns = sortConfig.filter(p => !p.startsWith('/')) || [];
+  if (sortPatterns.file_patterns.length) {
+    console.log(sortPatterns.folders);
+  }
+  return sortPatterns;
+}
+
+/**
+ * Recursively process a directory and build nested object structure
+ */
+async function processDirectoryRecursive(
+  dirPath: string,
+  configPath: string | null,
+  baseDir: string,
+): Promise<NestedObject | null> {
+  const result: NestedObject = {};
+
+  try {
+    // Get sorting patterns and folder patterns from config
+    let filePatterns: string[] = [];
+    let folderPatterns: string[] = [];
+    let mocLinks: string[] = [];
+
+    if (configPath) {
+      const config = await parseConfig(path.join(baseDir, configPath));
+      const sortPatterns = getSortPatterns(config);
+      if (sortPatterns.file_patterns?.length || sortPatterns?.folders?.length) {
+        filePatterns = sortPatterns.file_patterns;
+        folderPatterns = sortPatterns.folders;
+        const mocPatterns = filePatterns.filter(pattern =>
+          MOC_REGEX.test(pattern),
+        );
+        if (mocPatterns.length) {
+          mocLinks = await processMoCFiles(
+            path.join(baseDir, dirPath),
+            mocPatterns,
+          );
+        }
+      }
+    }
+
+    // Read directory contents and get stats
+    const items = await fs.readdir(path.join(baseDir, dirPath));
+    const stats = new Map<string, Stats>();
+    for (const item of items) {
+      stats.set(item, await fs.stat(path.join(baseDir, dirPath, item)));
+    }
+
+    // First, process all subdirectories
+    const folders = items.filter(item => stats.get(item)?.isDirectory());
+    const sortedFolders = sortDirectories(folders, folderPatterns);
+
+    for (const folder of sortedFolders) {
+      const fullPath = path.join(dirPath, folder);
+      const configFiles = await globAsync(
+        path.join(fullPath, '.config.{yaml,yml}'),
+        {
+          cwd: baseDir,
+          absolute: false,
+          dot: true,
+        },
+      );
+      // Find config for this subdirectory
+      const configYmlPath = configFiles[0] ?? null;
+      // Process subdirectory
+      const itemResults = await processDirectoryRecursive(
+        fullPath,
+        configYmlPath,
+        baseDir,
+      );
+      if (itemResults) {
+        result[folder] = itemResults;
+      }
+    }
+
+    const isHasConfig = items.some(
+      item =>
+        !stats.get(item)?.isDirectory() && /\.config\.(yaml|yml)$/i.test(item),
+    );
+    if (!isHasConfig) {
+      return result;
+    }
+
+    // Then, process files
+    const files = items.filter(
+      item => !stats.get(item)?.isDirectory() && /\.(md|mdx)$/i.test(item),
+    );
+
+    // Sort markdown files by patterns
+    const sortedMdFiles = sortMarkdownFiles(files, filePatterns, mocLinks);
+    for (const file of sortedMdFiles) {
+      result[file] = normalizePath(path.join(dirPath, file));
+    }
+
+    return result;
+  } catch (error) {
+    console.error(`Error processing directory ${dirPath}:`, error);
+    return null;
+  }
+}
+
+async function processVaultDirectory() {
+  return await processDirectoryRecursive(VAULT_DIR, null, '.');
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+  try {
+    // Find all config files in vault
+    const configFiles = await findConfigFiles(VAULT_DIR);
+    console.log(`Found ${configFiles.length} config files.`);
+
+    if (!configFiles.length) {
+      console.warn('No config files found');
+      return;
+    }
+    // Process the vault directory
+    const result = await processVaultDirectory();
+    if (!result) {
+      console.log('No valid config found in the vault.');
+      return;
+    }
+    // Write the result to menu-sorted.json
+    await fs.writeFile(OUTPUT_FILE, JSON.stringify(result, null, 2));
+    console.log('Successfully generated menu-sorted.json');
+  } catch (error) {
+    console.log('Error in main execution:', error);
+    process.exit(1);
+  }
+}
+
+// Execute the script
+main();

--- a/scripts/generate-menu-path-sorted.ts
+++ b/scripts/generate-menu-path-sorted.ts
@@ -19,7 +19,7 @@ const globAsync = (
 const VAULT_DIR = 'vault';
 const CONFIG_PATTERN = '**/.config.{yaml,yml}';
 const GLOB_MOC_FILE_PATTERN = '§*.md';
-const MOC_REGEX = /^\[§.*.md\]$/gi;
+const READING_FILE_REGEX = /^\[.*.md\]$/gi;
 const OUTPUT_FILE = 'public/content/menu-sorted.json';
 
 // Interfaces
@@ -170,7 +170,7 @@ function sortMarkdownFiles(
 
   // First, sort by patterns
   for (const pattern of filePatterns) {
-    if (MOC_REGEX.test(pattern)) continue; // Skip MoC pattern
+    if (READING_FILE_REGEX.test(pattern)) continue; // Skip the file need to be read pattern
 
     mdFiles.forEach(file => {
       if (matchPattern(file, pattern)) {
@@ -243,13 +243,13 @@ async function processDirectoryRecursive(
       if (sortPatterns.file_patterns?.length || sortPatterns?.folders?.length) {
         filePatterns = sortPatterns.file_patterns;
         folderPatterns = sortPatterns.folders;
-        const mocPatterns = filePatterns.filter(pattern =>
-          MOC_REGEX.test(pattern),
+        const readingFilePatternsList = filePatterns.filter(pattern =>
+          READING_FILE_REGEX.test(pattern),
         );
-        if (mocPatterns.length) {
+        if (readingFilePatternsList.length) {
           mocLinks = await processMoCFiles(
             path.join(baseDir, dirPath),
-            mocPatterns,
+            readingFilePatternsList,
           );
         }
       }

--- a/src/components/layout/DirectoryTree.tsx
+++ b/src/components/layout/DirectoryTree.tsx
@@ -37,15 +37,9 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
     const isOpen = openPaths[path];
     const hasChildren = Object.keys(node.children).length > 0;
     const itemChildren = Object.entries(node.children);
-    const withChildrenItems = itemChildren
-      .filter(([, childNode]) => {
-        return Object.keys(childNode.children).length > 0;
-      })
-      .sort(([, a], [, b]) => {
-        if (a.label < b.label) return -1;
-        if (a.label > b.label) return 1;
-        return 0;
-      });
+    const withChildrenItems = itemChildren.filter(([, childNode]) => {
+      return Object.keys(childNode.children).length > 0;
+    });
 
     const withoutChildrenItems = itemChildren.filter(([, childNode]) => {
       return Object.keys(childNode.children).length === 0;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,12 @@ export interface MenuFilePath {
   date: string; // Keep date for sorting
 }
 
+export interface NestedMenuPathTree {
+  [key: string]: string | NestedMenuPathTree;
+  // The key is the path, and the value can be a string or another nested object
+  // representing subdirectories.
+}
+
 /**
  * Interface for grouped path data (menu hierarchy node)
  */


### PR DESCRIPTION
#### What's this PR do?

- 📝 Added new script `generate-menu-path-sorted.ts` for tree menu node sorting
  - Implements recursive directory processing with config file support
  - Handles custom file sorting based on patterns and MoC (Map of Content) links
  - Generates menu-sorted.json output

- 🔧 Updated DirectoryTree.tsx 
  - Removed manual sorting logic
  - Simplified children items filtering

- 🛠 Enhanced content/utils.ts
  - Added getMenuPathSorted() function
  - Implemented recursive menu sorting functions
  - Applied sorted paths to directory tree transformation

- 🆕 Added new types in index.ts
  - New NestedMenuPathTree interface for menu path structure
  - Interface supports nested directory paths and file sorting

- 📦 Dependencies
  - Added @types/glob and glob packages
  - Updated package.json and pnpm-lock.yaml

- 📋 Makefile
  - Added generate-menu-path-sorted to the run command sequence

#### What are the relevant Git tickets?

- https://www.notion.so/dwarves/sort-merchanism-for-explore-tree-1ee64b29b84c80749457d09c93cf9e19

#### Screenshots (if appropriate)

<img width="236" alt="Screenshot 2025-05-14 at 10 10 03" src="https://github.com/user-attachments/assets/d369da97-ded5-4ee3-ad37-ad37617d7164" />
<img width="227" alt="Screenshot 2025-05-14 at 10 51 05" src="https://github.com/user-attachments/assets/1e3d34cf-bf23-43f8-952e-b99528c01491" />


#### Exampe Usage:

```yaml
sort:
  - /test
  - /assets
  - analysis-document.md
  - 202211081111-error-messaging.md
  - § Architecture.md # Indicate this is normal markdown file name pattern to be sorted
  - [§ Engineering.md] # Indicate this is regex too be read the file to get links
  - double-entry-accounting.md
```
