### PR TITLE
chore: redirects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,4 +14,6 @@ erl_crash.dump
 node_modules/
 out/
 
+public/content/nginx_redirect_map.conf
+
 scripts/notion/notion-output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,14 @@ LABEL maintainer="anhnx@d.foundation" \
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+# Copy static assets
 COPY --from=builder /code/out/ /usr/share/nginx/html
+
+# Copy the generated Nginx redirect map configuration
+COPY --from=builder /code/public/content/nginx_redirect_map.conf /etc/nginx/conf.d/nginx_redirect_map.conf
+
+# Copy custom Nginx configuration replace the default server block configuration
+COPY --from=builder /code/nginx/nginx.custom.conf /etc/nginx/conf.d/default.conf
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost/ || exit 1

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@ build:
 	@cd lib/obsidian-compiler && mix export_markdown
 	@cd lib/obsidian-compiler && mix duckdb.export
 	@pnpm run build
+	@pnpm run generate-nginx-conf
 	@cp -r db/ out/
 
 build-static:
 	@pnpm install --no-frozen-lockfile
 	@cd lib/obsidian-compiler && mix export_markdown
 	@pnpm run build
+	@pnpm run generate-nginx-conf
 	@cp -r db/ out/
 
 run:
@@ -36,6 +38,7 @@ run:
 	@pnpm run generate-backlinks
 	@pnpm run generate-search-index
 	@pnpm run generate-redirects-map
+	@pnpm run generate-shorten-map
 	@pnpm run generate-user-profiles
 	@pnpm run fetch-prompts
 	@pnpm run dev

--- a/nginx/nginx.custom.conf
+++ b/nginx/nginx.custom.conf
@@ -24,6 +24,9 @@ server {
     location / {
         # Check if the requested URI has a redirect target in our map
         if ($redirect_target != 0) {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
             return 301 $redirect_target$is_args$args;
         }
 

--- a/nginx/nginx.custom.conf
+++ b/nginx/nginx.custom.conf
@@ -1,0 +1,66 @@
+# This file will be included by the main nginx.conf or replace it.
+# It assumes nginx_redirect_map.conf is in the same directory or a known path.
+
+# Increase the hash bucket size for larger maps
+# This is necessary if you have a large number of redirects.
+# Current implementation capability for 100k lines.
+map_hash_bucket_size 256;
+map_hash_max_size 131072;
+
+# Include the generated redirect map
+# The path might need adjustment based on where it's copied in the Docker image.
+# For now, assuming it's in /etc/nginx/conf.d/ or similar.
+# We will copy nginx_redirect_map.conf to /etc/nginx/conf.d/ in the Dockerfile.
+include /etc/nginx/conf.d/nginx_redirect_map.conf;
+
+server {
+    listen 80;
+    server_name localhost; # Adjust as necessary
+
+    # Root directory for your static Next.js export
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location / {
+        # Check if the requested URI has a redirect target in our map
+        if ($redirect_target != 0) {
+            return 301 $redirect_target$is_args$args;
+        }
+
+        # If no redirect, try to serve the file according to Next.js SSG structure
+        # 1. Try direct file match (for assets like .css, .js, images)
+        # 2. Try URI with .html appended (for pages like /about -> /about.html)
+        # 3. Try URI as a directory with index.html (for /path -> /path/index.html)
+        # 4. Fallback to 404 page
+        try_files $uri $uri.html ${uri}/index.html /404.html;
+    }
+
+    # Standard error pages
+    error_page 404 /404.html;
+    location = /404.html {
+        root /usr/share/nginx/html; # Ensure Nginx can find 404.html
+        internal;
+    }
+
+    # You might not have a generic 50x.html with Next.js SSG.
+    # Nginx's default 50x page will be used if not specified and present.
+    # If you have a custom 50x.html, uncomment and adjust:
+    # error_page 500 502 503 504 /50x.html;
+    # location = /50x.html {
+    #     root /usr/share/nginx/html;
+    #     internal;
+    # }
+
+    # Deny access to hidden files
+    location ~ /\. {
+        deny all;
+    }
+
+    # Add any other specific Nginx configurations you need
+    # For example, gzip compression, cache control headers, etc.
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+}

--- a/nginx/nginx.custom.conf
+++ b/nginx/nginx.custom.conf
@@ -21,6 +21,13 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
 
+    # Optional: Remove trailing slash for non-root URIs
+    # This helps normalize URIs before they hit the main location block and redirect map.
+    # It prevents issues where a redirect map might only have entries for /path but not /path/.
+    location ~ ^/(.+)/$ {
+        return 301 /$1$is_args$args;
+    }
+
     location / {
         # Check if the requested URI has a redirect target in our map
         if ($redirect_target != 0) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm run generate-menu && pnpm run generate-menu-path-sorted && pnpm run generate-backlinks && pnpm run generate-search-index && pnpm run generate-redirects-map && pnpm run generate-user-profiles && pnpm run fetch-prompts && next build && pnpm run generate-rss && pnpm run copy-404",
+    "build": "pnpm run generate-menu && pnpm run generate-menu-path-sorted && pnpm run generate-backlinks && pnpm run generate-search-index && pnpm run generate-redirects-map && pnpm run generate-shorten-map && pnpm run generate-user-profiles && pnpm run fetch-prompts && next build && pnpm run generate-rss && pnpm run copy-404",
     "start": "next start",
     "lint": "next lint",
     "deploy": "gh-pages -d out",
@@ -14,10 +14,12 @@
     "generate-rss": "tsx scripts/generate-rss.ts",
     "generate-search-index": "tsx scripts/generate-search-index.ts",
     "generate-redirects-map": "tsx scripts/generate-redirects-map.ts",
+    "generate-shorten-map": "tsx scripts/generate-shorten-map.ts",
     "generate-menu": "tsx scripts/generate-menu.ts",
     "generate-backlinks": "tsx scripts/generate-backlinks.ts",
     "generate-summary": "tsx scripts/generate-summary.ts",
     "generate-user-profiles": "tsx scripts/generate-user-profiles.ts",
+    "generate-nginx-conf": "tsx scripts/generate-nginx-redirect-map.ts",
     "fetch-prompts": "tsx scripts/fetch-prompts.ts",
     "generate-menu-path-sorted": "tsx scripts/generate-menu-path-sorted.ts",
     "copy-404": "cp out/404/index.html out/404.html"

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -1,0 +1,188 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { exec } from 'child_process';
+
+const CONTENT_DIR = path.join(process.cwd(), 'public/content');
+const REDIRECTS_JSON_PATH = path.join(CONTENT_DIR, 'redirects.json');
+const ALIAS_JSON_PATH = path.join(CONTENT_DIR, 'aliases.json');
+
+function removingTrailingSlash(path: string): string {
+  return path.replace(/\/$/, '');
+}
+
+function removingRedundantSymbols(path: string): string {
+  return path.replace(/\"|"/, '');
+}
+
+export function normalizePathWithSlash(path: string): string {
+  if (path.startsWith('/')) {
+    return removingTrailingSlash(removingRedundantSymbols(path));
+  }
+  return removingTrailingSlash(removingRedundantSymbols(`/${path}`));
+}
+
+export async function getJSONFileContent(
+  filePath: string,
+): Promise<Record<string, string>> {
+  try {
+    const jsonContent = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(jsonContent);
+  } catch (error) {
+    console.warn(
+      `Warning: Could not read or parse ${filePath}. Error: ${(error as Error).message}`,
+    );
+    return {};
+  }
+}
+
+export async function execPromise(command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = exec(command, { cwd: process.cwd() }, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    child.stdout?.pipe(process.stdout);
+    child.stderr?.pipe(process.stderr);
+  });
+}
+
+/**
+ * Gets all markdown and MDX files recursively from a directory
+ * @param dir The directory to search in
+ * @param basePath The base path for the current directory
+ * @returns Array of slug arrays for each markdown/MDX file
+ */
+export async function getAllMarkdownFiles(
+  dir: string,
+  basePath: string[] = [],
+): Promise<string[][]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    console.error(`Error reading directory ${dir}: ${error}`);
+    return [];
+  }
+
+  const paths: string[][] = [];
+
+  // Check for readme files (markdown and MDX)
+  const readmeFilePath = path.join(dir, 'readme.md');
+  const readmeMdxFilePath = path.join(dir, 'readme.mdx');
+  const indexFilePath = path.join(dir, '_index.md');
+  const indexMdxFilePath = path.join(dir, '_index.mdx');
+
+  let readmeExists = false;
+  try {
+    // Check for readme.md first
+    await fs.stat(readmeFilePath);
+    readmeExists = true;
+  } catch {
+    // If readme.md doesn't exist, try readme.mdx
+    try {
+      await fs.stat(readmeMdxFilePath);
+      readmeExists = true;
+    } catch {
+      // Neither exists
+    }
+  }
+
+  let indexExists = false;
+  try {
+    // Check for _index.md first
+    await fs.stat(indexFilePath);
+    indexExists = true;
+  } catch {
+    // If _index.md doesn't exist, try _index.mdx
+    try {
+      await fs.stat(indexMdxFilePath);
+      indexExists = true;
+    } catch {
+      // Neither exists
+    }
+  }
+
+  // Prioritize readme over _index
+  if (readmeExists && basePath.length > 0) {
+    paths.push([...basePath]);
+    paths.push([...basePath, 'readme']);
+  } else if (indexExists && basePath.length > 0) {
+    paths.push([...basePath]);
+  } else if (entries.length > 0 && basePath.length > 0) {
+    paths.push([...basePath]);
+  }
+
+  for (const entry of entries) {
+    const res = path.resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      paths.push(
+        ...(await getAllMarkdownFiles(res, [...basePath, entry.name])),
+      );
+    } else if (
+      // Include both .md and .mdx files
+      (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) &&
+      entry.name !== '_index.md' &&
+      entry.name !== '_index.mdx' &&
+      entry.name !== 'readme.md' &&
+      entry.name !== 'readme.mdx'
+    ) {
+      // Remove file extension (.md or .mdx) for the slug
+      const slugName = entry.name.replace(/\.(md|mdx)$/, '');
+      paths.push([...basePath, slugName]);
+    }
+  }
+
+  return paths;
+}
+
+export async function getAliasPaths(): Promise<Record<string, string>> {
+  const aliases = await getJSONFileContent(ALIAS_JSON_PATH);
+
+  const excludePaths = ['index'];
+
+  // 1. Gather nested alias paths by enumerating all children under each alias target
+  const nestedAliasPaths: Record<string, string> = {};
+  for (const aliasKey in aliases) {
+    const aliasValue = aliases[aliasKey].split('/').filter(Boolean).join('/');
+    const aliasKeySegments = aliasKey.split('/').filter(Boolean);
+    const targetDir = path.join(CONTENT_DIR, ...aliasValue.split('/'));
+    let childSlugs: string[][] = [];
+    try {
+      childSlugs = await getAllMarkdownFiles(targetDir);
+    } catch {
+      // If the alias target doesn't exist, skip
+      continue;
+    }
+    for (const childSlug of childSlugs) {
+      // Don't add the root alias itself (handled by aliasPaths)
+      if (childSlug.length === 0) {
+        continue;
+      }
+      const newAliasSlug = [...aliasKeySegments, ...childSlug].join('/');
+      const redirectTarget = [aliasValue, ...childSlug].join('/');
+      if (excludePaths.includes(newAliasSlug)) {
+        continue;
+      }
+      nestedAliasPaths[newAliasSlug] = redirectTarget;
+    }
+  }
+  return Object.assign({}, aliases, nestedAliasPaths);
+}
+
+export async function getReversedAliasPaths(): Promise<Record<string, string>> {
+  const aliases = await getAliasPaths();
+
+  // Reverse the keys and values
+  const reversedAliases = Object.fromEntries(
+    Object.entries(aliases).map(([key, value]) => [value, key]),
+  );
+  return reversedAliases;
+}
+
+export async function getRedirects(): Promise<Record<string, string>> {
+  const redirects = await getJSONFileContent(REDIRECTS_JSON_PATH);
+  return redirects;
+}

--- a/scripts/generate-nginx-redirect-map.ts
+++ b/scripts/generate-nginx-redirect-map.ts
@@ -1,0 +1,64 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {
+  getReversedAliasPaths,
+  getJSONFileContent,
+  getRedirects,
+  normalizePathWithSlash,
+} from './common.js';
+
+const CONTENT_DIR = path.join(process.cwd(), 'public/content');
+const SHORTEN_REDIRECTS_JSON_PATH = path.join(
+  CONTENT_DIR,
+  'shorten-redirects.json',
+);
+const NGINX_MAP_OUTPUT_PATH = path.join(CONTENT_DIR, 'nginx_redirect_map.conf');
+
+async function generateNginxRedirectMap() {
+  const redirects = await getRedirects();
+  const alias = await getReversedAliasPaths();
+  const shortenRedirects = await getJSONFileContent(
+    SHORTEN_REDIRECTS_JSON_PATH,
+  );
+
+  let mapContent = 'map $request_uri $redirect_target {\n';
+  mapContent += '    default 0;\n';
+
+  const paths = [redirects, alias, shortenRedirects];
+  // Flatten the array of objects into a single array of objects
+  const flattenedPaths = paths.reduce<Record<string, string>>((acc, obj) => {
+    const mapEntries = Object.entries(obj).map<Record<string, string>>(
+      ([key, value]) => ({
+        [normalizePathWithSlash(key)]: normalizePathWithSlash(value),
+      }),
+    );
+    return Object.assign(acc, ...mapEntries);
+  }, {});
+
+  for (const sourceUri in flattenedPaths) {
+    if (Object.prototype.hasOwnProperty.call(flattenedPaths, sourceUri)) {
+      const targetUri = flattenedPaths[sourceUri];
+      // Skip empty or self-referential redirects
+      if (!targetUri || sourceUri === targetUri) {
+        continue;
+      }
+      // Ensure proper quoting if URIs contain special characters, though typically they shouldn't for Nginx map keys.
+      // Nginx map keys are typically matched literally.
+      mapContent += `    "${sourceUri}" "${targetUri}";\n`;
+    }
+  }
+
+  mapContent += '}\n';
+
+  try {
+    await fs.writeFile(NGINX_MAP_OUTPUT_PATH, mapContent, 'utf-8');
+    console.log(`Nginx redirect map generated at ${NGINX_MAP_OUTPUT_PATH}`);
+  } catch (error) {
+    console.error(
+      `Error writing Nginx redirect map to ${NGINX_MAP_OUTPUT_PATH}: ${(error as Error).message}`,
+    );
+    process.exit(1);
+  }
+}
+
+generateNginxRedirectMap();

--- a/scripts/generate-redirects-from-frontmatter.ts
+++ b/scripts/generate-redirects-from-frontmatter.ts
@@ -1,0 +1,225 @@
+import fs from 'fs/promises';
+import path from 'path';
+import matter from 'gray-matter';
+import crypto from 'crypto';
+import minimist from 'minimist';
+
+const VAULT_PATH = path.join(process.cwd(), 'vault');
+
+interface RedirectsMap {
+  [alias: string]: string;
+}
+
+/**
+ * Recursively find all markdown/mdx files in a directory
+ */
+async function findMarkdownFiles(dir: string): Promise<string[]> {
+  let files: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== '.git') {
+        const subFiles = await findMarkdownFiles(fullPath);
+        files = files.concat(subFiles);
+      }
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith('.md') || entry.name.endsWith('.mdx'))
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Generate a random short alias string of 6-8 characters
+ */
+function generateRandomAlias(): string {
+  // Generate 4 random bytes and convert to base64url string, then take 6-8 chars
+  const randomBytes = crypto.randomBytes(4);
+  const base64url = randomBytes
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return base64url.slice(0, 7); // 7 chars for balance
+}
+
+/**
+ * Format a file path to a URL path starting with '/'
+ * Remove vault prefix and file extension
+ */
+function formatFilePathToUrl(filePath: string): string {
+  const relativePath = path.relative(VAULT_PATH, filePath);
+  const noExt = relativePath.replace(/\.mdx?$/, '');
+  // Use forward slashes for URLs
+  return '/' + noExt.split(path.sep).join('/');
+}
+
+/**
+ * Main function to generate redirects map from frontmatter
+ */
+async function generateRedirectsFromFrontmatter() {
+  const argv = minimist(process.argv.slice(2));
+
+  const targetPath = argv._[0];
+
+  if (!targetPath) {
+    console.error('Please provide a target path to scan for markdown files.');
+    process.exit(1);
+  }
+
+  const redirects: RedirectsMap = {};
+
+  const files = await findMarkdownFiles(targetPath);
+
+  // Map to track used aliases to detect duplicates
+  const usedAliases = new Set<string>();
+
+  for (const file of files) {
+    try {
+      const content = await fs.readFile(file, 'utf-8');
+      const { data: frontmatter } = matter(content);
+
+      const canonicalPath = formatFilePathToUrl(file);
+
+      // If frontmatter has redirect property and is array
+      if (frontmatter.redirect && Array.isArray(frontmatter.redirect)) {
+        for (const aliasRaw of frontmatter.redirect) {
+          if (typeof aliasRaw === 'string') {
+            const alias = aliasRaw.startsWith('/') ? aliasRaw : '/' + aliasRaw;
+            if (usedAliases.has(alias)) {
+              console.warn(
+                `Duplicate alias detected: ${alias} in file ${file}. Skipping.`,
+              );
+            } else {
+              usedAliases.add(alias);
+            }
+          }
+        }
+      } else {
+        // No redirect property, generate a random alias
+        let alias: string;
+        do {
+          alias = '/s/' + generateRandomAlias();
+        } while (usedAliases.has(alias));
+        redirects[alias] = canonicalPath;
+        usedAliases.add(alias);
+
+        // Update the file frontmatter to add the generated alias
+        // Read original content again to preserve formatting
+        const originalContent = await fs.readFile(file, 'utf-8');
+        const parsed = matter(originalContent);
+        const newRedirects = [alias];
+        if (parsed.data.redirect && Array.isArray(parsed.data.redirect)) {
+          newRedirects.push(...parsed.data.redirect);
+        }
+
+        // Helper function to update redirect property in frontmatter preserving formatting
+        function updateRedirectFrontmatter(
+          content: string,
+          newRedirects: string[],
+        ): string {
+          const lines = content.split('\n');
+          let inFrontmatter = false;
+          let frontmatterStart = -1;
+          let frontmatterEnd = -1;
+          for (let i = 0; i < lines.length; i++) {
+            if (lines[i].trim() === '---') {
+              if (!inFrontmatter) {
+                inFrontmatter = true;
+                frontmatterStart = i;
+              } else {
+                frontmatterEnd = i;
+                break;
+              }
+            }
+          }
+          if (frontmatterStart === -1 || frontmatterEnd === -1) {
+            // No frontmatter found, return original content
+            return content;
+          }
+
+          // Extract frontmatter lines
+          const fmLines = lines.slice(frontmatterStart + 1, frontmatterEnd);
+
+          // Find redirect property lines
+          let redirectStart = -1;
+          let redirectEnd = -1;
+          for (let i = 0; i < fmLines.length; i++) {
+            if (fmLines[i].match(/^redirect:/)) {
+              redirectStart = i;
+              // Find end of redirect block (next non-indented line or end)
+              for (let j = i + 1; j < fmLines.length; j++) {
+                if (!fmLines[j].match(/^\s+-\s+/)) {
+                  redirectEnd = j - 1;
+                  break;
+                }
+              }
+              if (redirectEnd === -1) {
+                redirectEnd = fmLines.length - 1;
+              }
+              break;
+            }
+          }
+
+          // Determine indentation
+          const indent =
+            redirectStart !== -1
+              ? (fmLines[redirectStart].match(/^(\s*)/)?.[1] ?? '')
+              : '';
+
+          // Build new redirect block lines
+          const newRedirectLines = [];
+          if (newRedirects.length === 0) {
+            newRedirectLines.push(`${indent}redirect: []`);
+          } else {
+            newRedirectLines.push(`${indent}redirect:`);
+            const itemIndent = indent + '  ';
+            for (const alias of newRedirects) {
+              newRedirectLines.push(`${itemIndent}- ${alias}`);
+            }
+          }
+
+          // Replace or insert redirect block
+          let newFmLines;
+          if (redirectStart !== -1) {
+            newFmLines = [
+              ...fmLines.slice(0, redirectStart),
+              ...newRedirectLines,
+              ...fmLines.slice(redirectEnd + 1),
+            ];
+          } else {
+            // Insert redirect block at the end of frontmatter
+            newFmLines = [...fmLines, ...newRedirectLines];
+          }
+
+          // Rebuild content
+          const newLines = [
+            ...lines.slice(0, frontmatterStart + 1),
+            ...newFmLines,
+            ...lines.slice(frontmatterEnd),
+          ];
+
+          return newLines.join('\n');
+        }
+
+        const newContent = updateRedirectFrontmatter(
+          originalContent,
+          newRedirects,
+        );
+
+        await fs.writeFile(file, newContent, 'utf-8');
+        console.log(`Added redirect alias ${alias} to ${file}`);
+      }
+    } catch (error) {
+      console.error(`Error processing file ${file}:`, error);
+    }
+  }
+
+  console.log('Shorten alias generated: ', Object.keys(redirects).length);
+}
+
+generateRedirectsFromFrontmatter();

--- a/scripts/generate-shorten-map.ts
+++ b/scripts/generate-shorten-map.ts
@@ -1,0 +1,140 @@
+import fs from 'fs/promises';
+import path from 'path';
+import matter from 'gray-matter';
+import {
+  getRedirects,
+  getReversedAliasPaths,
+  normalizePathWithSlash,
+} from './common.js';
+
+const VAULT_PATH = path.join(process.cwd(), 'vault');
+const REDIRECTS_OUTPUT_PATH = path.join(
+  process.cwd(),
+  'public/content/shorten-redirects.json',
+);
+
+interface RedirectsMap {
+  [alias: string]: string;
+}
+
+/**
+ * Recursively find all markdown/mdx files in a directory
+ */
+async function findMarkdownFiles(dir: string): Promise<string[]> {
+  let files: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== '.git') {
+        const subFiles = await findMarkdownFiles(fullPath);
+        files = files.concat(subFiles);
+      }
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith('.md') || entry.name.endsWith('.mdx'))
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Format a file path to a URL path starting with '/'
+ * Remove vault prefix and file extension
+ */
+function formatFilePathToUrl(filePath: string): string {
+  const relativePath = path.relative(VAULT_PATH, filePath);
+  const noExt = relativePath.replace(/\.mdx?$/, '');
+  // Replace spacing to hyphens and remove special characters
+  const sanitizedPath = noExt
+    .replace(/ /g, '-')
+    .replace(/--+/g, '-')
+    .split('/')
+    .map(
+      segment =>
+        segment.replace(/[^a-zA-Z0-9-_\/]/g, '').replace(/^-+|-+$/g, ''), // Remove leading/trailing hyphens
+    )
+    .join('/');
+
+  // Use forward slashes for URLs
+  return ('/' + sanitizedPath.split(path.sep).join('/')).toLowerCase();
+}
+
+function getRedirectPaths(
+  rawPath: string,
+  aliases: Record<string, string>,
+  redirects: Record<string, string>,
+) {
+  if (aliases[rawPath]) {
+    return normalizePathWithSlash(aliases[rawPath]);
+  }
+  if (redirects[rawPath]) {
+    return normalizePathWithSlash(redirects[rawPath]);
+  }
+  // If no match, return itself
+  return normalizePathWithSlash(rawPath);
+}
+
+function normalizePaths(paths: Record<string, string>) {
+  const normalized: Record<string, string> = {};
+  for (const key in paths) {
+    const value = paths[key];
+    normalized[normalizePathWithSlash(key)] = normalizePathWithSlash(value);
+  }
+  return normalized;
+}
+
+/**
+ * Main function to generate redirects map from frontmatter
+ */
+async function generateShortenRedirectsJSON() {
+  const redirects: RedirectsMap = {};
+
+  const files = await findMarkdownFiles(VAULT_PATH);
+  const reversedAliases = normalizePaths(await getReversedAliasPaths());
+  const redirectPaths = normalizePaths(await getRedirects());
+
+  // Map to track used aliases to detect duplicates
+  const usedAliases = new Set<string>();
+
+  for (const file of files) {
+    try {
+      const content = await fs.readFile(file, 'utf-8');
+      const { data: frontmatter } = matter(content);
+
+      if (!frontmatter.redirect || !Array.isArray(frontmatter.redirect)) {
+        // Skip if no redirect property or not an array
+        continue;
+      }
+      const canonicalPath = getRedirectPaths(
+        formatFilePathToUrl(file),
+        reversedAliases,
+        redirectPaths,
+      );
+
+      for (const aliasRaw of frontmatter.redirect) {
+        if (typeof aliasRaw === 'string') {
+          const alias = aliasRaw.startsWith('/') ? aliasRaw : '/' + aliasRaw;
+          if (usedAliases.has(alias)) {
+            console.warn(
+              `Duplicate alias detected: ${alias} in file ${file}. Skipping.`,
+            );
+          } else {
+            redirects[alias] = canonicalPath;
+            usedAliases.add(alias);
+          }
+        }
+      }
+    } catch (error) {
+      //
+    }
+  }
+
+  // Write redirects map to JSON file
+  await fs.writeFile(REDIRECTS_OUTPUT_PATH, JSON.stringify(redirects, null, 2));
+  console.log(`Redirects map written to ${REDIRECTS_OUTPUT_PATH}`);
+}
+
+generateShortenRedirectsJSON();


### PR DESCRIPTION
## Description
- Centralizes alias and redirect logic in Nginx. The `generate-nginx-redirect-map.ts` script now sources from `redirects.json`, `aliases.json` (with nested path generation), and `shorten-redirects.json`. Next.js page (`[...slug].tsx`) simplified by removing its redirect handling.

- Refactors Nginx redirect map generation to be part of the `build-static` Makefile target via a new `generate-nginx-conf` pnpm script. Updates `nginx.custom.conf` `try_files` for better Next.js SSG compatibility.

- Implements a new redirect system using Nginx, driven by markdown frontmatter.

> *   `scripts/generate-redirects-from-frontmatter.ts`: New script to create/update short aliases in frontmatter and generate `shorten-redirects.json`.
> *   `scripts/generate-nginx-redirect-map.ts`: New script to create `nginx_redirect_map.conf`.
> *   `nginx/nginx.custom.conf`: New Nginx configuration using the redirect map.
> *   `Dockerfile`: Integrates these scripts and deploys the new Nginx setup.

```mermaid
sequenceDiagram
    participant CI/Dev as CI/Developer
    participant MarkdownFiles as Markdown Files (vault/)
    participant GenFrontmatter as generate-redirects.ts
    participant AliasesJSON as public/content/aliases.json
    participant GenShortenMap as generate-shorten-map.ts
    participant ShortenRedirectsJSON as public/content/shorten-redirects.json
    participant GenNginxConf as generate-nginx-redirect-map.ts
    participant NginxRedirectMapConf as public/content/nginx_redirect_map.conf
    participant DockerBuild as Docker Build
    participant NginxContainer as Nginx Container

    CI/Dev->>GenFrontmatter: Run script (e.g., dispatch/main branch pushing)
    GenFrontmatter->>MarkdownFiles: Read content & frontmatter
    alt No 'redirect' alias
        GenFrontmatter->>GenFrontmatter: Generate random short alias
        GenFrontmatter->>MarkdownFiles: Update frontmatter with new alias
    end

    CI/Dev->>GenShortenMap: Trigger build (Makefile: pnpm run generate-shorten-map)
    GenShortenMap->>MarkdownFiles: Read frontmatter
    GenShortenMap->>AliasesJSON: Get aliases
    GenShortenMap->>GenShortenMap: Generate shorten redirects
    GenShortenMap->>ShortenRedirectsJSON: Write shorten redirects map

    CI/Dev->>GenNginxConf: Trigger build (Makefile: pnpm run generate-nginx-conf)
    ShortenRedirectsJSON->>GenNginxConf: Get Shorten Redirects map JSON
    AliasesJSON->>GenNginxConf: Get Alias Redirects map JSON
    GenNginxConf->>GenNginxConf: Generate Nginx map configuration
    GenNginxConf->>NginxRedirectMapConf: Write Nginx config

    CI/Dev->>DockerBuild: Build Docker image
    DockerBuild->>NginxRedirectMapConf: Copy to /etc/nginx/conf.d/
    DockerBuild->>NginxContainer: Include in image

    NginxContainer->>NginxRedirectMapConf: Load configuration at runtime
    NginxContainer->>NginxContainer: Handle URL redirects based on map
```