### PR TITLE
fix: include redirect for link with file extension

### DIFF
--- a/scripts/generate-redirects-map.ts
+++ b/scripts/generate-redirects-map.ts
@@ -154,6 +154,22 @@ async function generateRedirectsMap() {
         }
       }
 
+      // Add redirects for .md files to their non-.md versions
+      if (
+        filePath &&
+        filePath.toLowerCase().endsWith('.md') &&
+        !/\/README\.md$/i.test(filePath)
+      ) {
+        const slugifiedMdPath = slugifyPathComponents(filePath);
+        const slugifiedNonMdPath = slugifiedMdPath.endsWith('.md')
+          ? slugifiedMdPath.slice(0, -3)
+          : slugifiedMdPath;
+
+        if (slugifiedMdPath !== slugifiedNonMdPath) {
+          redirects[slugifiedMdPath] = slugifiedNonMdPath;
+        }
+      }
+
       // Process short links
       if (shortLinks && Array.isArray(shortLinks)) {
         for (const shortLink of shortLinks) {


### PR DESCRIPTION
```diff
diff --git a/main.conf b/fix.conf
index 88d1a12..a0f7626 100644
--- a/main.conf
+++ b/fix.conf
@@ -1014,20 +1014,78 @@ map $request_uri $redirect_target {
     "/research/topics" "/topics";
     "/updates/build-log" "/build-log";
     "/updates/changelog" "/changelog";
+    "/handbook/as-a-community.md" "/handbook/as-a-community";
     "/handbook/community/dwarves-community" "/handbook/as-a-community";
+    "/handbook/community/icy.md" "/handbook/community/icy";
     "/handbook/icy" "/handbook/community/icy";
+    "/radar/index/argocd.md" "/radar/index/argocd";
+    "/radar/index/prometheus.md" "/radar/index/prometheus";
+    "/radar/index/page-object-model.md" "/radar/index/page-object-model";
+    "/radar/index/astro.md" "/radar/index/astro";
+    "/radar/index/trunk-based-development.md" "/radar/index/trunk-based-development";
+    "/radar/index/svelte.md" "/radar/index/svelte";
+    "/radar/index/solidjs.md" "/radar/index/solidjs";
+    "/radar/index/large-language-model-llm.md" "/radar/index/large-language-model-llm";
+    "/radar/index/devpod.md" "/radar/index/devpod";
+    "/radar/index/ladle.md" "/radar/index/ladle";
+    "/radar/index/wasm.md" "/radar/index/wasm";
+    "/radar/index/nextjs.md" "/radar/index/nextjs";
+    "/radar/index/jotai.md" "/radar/index/jotai";
+    "/radar/index/fullstack-tracing.md" "/radar/index/fullstack-tracing";
+    "/radar/index/orval.md" "/radar/index/orval";
+    "/radar/index/chatgpt-assistance.md" "/radar/index/chatgpt-assistance";
+    "/radar/index/type-safe-client-server.md" "/radar/index/type-safe-client-server";
+    "/radar/index/langchain.md" "/radar/index/langchain";
+    "/radar/index/dora-metrics.md" "/radar/index/dora-metrics";
+    "/radar/index/duckdb.md" "/radar/index/duckdb";
+    "/radar/index/sentry.md" "/radar/index/sentry";
+    "/radar/index/expo.md" "/radar/index/expo";
+    "/radar/index/vector-database.md" "/radar/index/vector-database";
+    "/radar/index/swr.md" "/radar/index/swr";
+    "/radar/index/playwright.md" "/radar/index/playwright";
+    "/radar/index/react-hook-form.md" "/radar/index/react-hook-form";
+    "/radar/index/react-query.md" "/radar/index/react-query";
+    "/radar/index/newrelic.md" "/radar/index/newrelic";
+    "/radar/index/webdriverio.md" "/radar/index/webdriverio";
+    "/radar/index/apache-kafka.md" "/radar/index/apache-kafka";
+    "/radar/index/k6.md" "/radar/index/k6";
+    "/radar/index/codecept.md" "/radar/index/codecept";
+    "/radar/index/react.md" "/radar/index/react";
+    "/radar/index/v-model.md" "/radar/index/v-model";
+    "/radar/index/react-llm.md" "/radar/index/react-llm";
+    "/radar/index/blue-green-deployment.md" "/radar/index/blue-green-deployment";
+    "/radar/index/github-actions.md" "/radar/index/github-actions";
+    "/radar/index/progressive-delivery.md" "/radar/index/progressive-delivery";
+    "/radar/index/grafana.md" "/radar/index/grafana";
+    "/radar/index/qwik.md" "/radar/index/qwik";
+    "/radar/index/nestjs.md" "/radar/index/nestjs";
+    "/radar/index/selenium.md" "/radar/index/selenium";
+    "/radar/index/eslint.md" "/radar/index/eslint";
+    "/radar/index/msw.md" "/radar/index/msw";
+    "/radar/index/remix.md" "/radar/index/remix";
+    "/radar/index/detox.md" "/radar/index/detox";
+    "/radar/index/copilot.md" "/radar/index/copilot";
+    "/radar/index/cucumber.md" "/radar/index/cucumber";
+    "/radar/index/devcontainers.md" "/radar/index/devcontainers";
+    "/culture/high-performing-team.md" "/culture/high-performing-team";
+    "/culture/blocking-distraction.md" "/culture/blocking-distraction";
+    "/research/nomination.md" "/research/nomination";
....list is too long
```