### PR TITLE
fix: optimize share button spacing on mobile

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -86,62 +86,118 @@ const ShareButton = (props: Props) => {
 
   return (
     <div className={cn('inline-flex', className)} role="group">
-      <Button
-        variant="outline"
-        className="flex items-center gap-2 rounded-r-none text-sm shadow-none"
-        size="sm"
-        onClick={() => setIsShareDialogOpen(true)}
-      >
-        <Share2Icon className="text-muted-foreground !h-4 !w-4" />
-        Share
-      </Button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            className="!w-8 min-w-auto rounded-l-none border-l-0 shadow-none"
-          >
-            <ChevronDownIcon className="text-muted-foreground !h-4 !w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={() => copyMemoContent()}
-          >
-            <CopyIcon className="mr-2 h-4 w-4" />
-            <span>Copy page</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={() => copyLinktoClipboard()}
-          >
-            <LinkIcon className="mr-2 h-4 w-4" />
-            <span>Copy link</span>
-          </DropdownMenuItem>
-          {metadata?.sprContent ? (
+      {/* Desktop: Show full button with text */}
+      <div className="hidden sm:flex">
+        <Button
+          variant="outline"
+          className="flex items-center gap-2 rounded-r-none text-sm shadow-none"
+          size="sm"
+          onClick={() => setIsShareDialogOpen(true)}
+        >
+          <Share2Icon className="text-muted-foreground !h-4 !w-4" />
+          Share
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="!w-8 min-w-auto rounded-l-none border-l-0 shadow-none"
+            >
+              <ChevronDownIcon className="text-muted-foreground !h-4 !w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
             <DropdownMenuItem
               className="cursor-pointer"
-              onClick={() =>
-                createPrintableMarkdown(
-                  {
-                    title: metadata.title,
-                    spr_content: metadata.sprContent!,
-                  },
-                  getPageUrl,
-                )
-              }
+              onClick={() => copyMemoContent()}
             >
-              <PrinterIcon className="mr-2 h-4 w-4" />
-              <span>Print lesson</span>
+              <CopyIcon className="mr-2 h-4 w-4" />
+              <span>Copy page</span>
             </DropdownMenuItem>
-          ) : null}
-          {/* <DropdownMenuItem className="cursor-pointer">
-              <Printer className="mr-2 h-4 w-4" /> <span>Print cheatsheet</span>
-            </DropdownMenuItem> */}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() => copyLinktoClipboard()}
+            >
+              <LinkIcon className="mr-2 h-4 w-4" />
+              <span>Copy link</span>
+            </DropdownMenuItem>
+            {metadata?.sprContent ? (
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() =>
+                  createPrintableMarkdown(
+                    {
+                      title: metadata.title,
+                      spr_content: metadata.sprContent!,
+                    },
+                    getPageUrl,
+                  )
+                }
+              >
+                <PrinterIcon className="mr-2 h-4 w-4" />
+                <span>Print lesson</span>
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Mobile: Icon-only dropdown with all share options */}
+      <div className="flex sm:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="!w-8 min-w-auto shadow-none"
+              aria-label="Share options"
+            >
+              <Share2Icon className="text-muted-foreground !h-4 !w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() => setIsShareDialogOpen(true)}
+            >
+              <Share2Icon className="mr-2 h-4 w-4" />
+              <span>Share</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() => copyMemoContent()}
+            >
+              <CopyIcon className="mr-2 h-4 w-4" />
+              <span>Copy page</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() => copyLinktoClipboard()}
+            >
+              <LinkIcon className="mr-2 h-4 w-4" />
+              <span>Copy link</span>
+            </DropdownMenuItem>
+            {metadata?.sprContent ? (
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() =>
+                  createPrintableMarkdown(
+                    {
+                      title: metadata.title,
+                      spr_content: metadata.sprContent!,
+                    },
+                    getPageUrl,
+                  )
+                }
+              >
+                <PrinterIcon className="mr-2 h-4 w-4" />
+                <span>Print lesson</span>
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     </div>
   );
 };

--- a/src/components/layout/ContentLayout.tsx
+++ b/src/components/layout/ContentLayout.tsx
@@ -65,12 +65,12 @@ const ContentLayout: React.FC<ContentLayoutProps> = ({
     <div className="content-layout xl:m-h-[400px]">
       {/* Title section */}
       {!hideTitle && (
-        <div className="flex-start flex justify-between space-x-2">
-          <h1 className="mt-0 mb-5 pb-0 font-serif text-3xl leading-[1.2em] font-semibold tracking-tight md:text-[35px]">
+        <div className="flex items-start justify-between gap-3 sm:gap-4">
+          <h1 className="mt-0 mb-5 min-w-0 flex-1 pb-0 font-serif text-3xl leading-[1.2em] font-semibold tracking-tight md:text-[35px]">
             {formattedTitle}
           </h1>
 
-          <ShareButton className="mt-2" metadata={metadata} />
+          <ShareButton className="mt-2 flex-shrink-0" metadata={metadata} />
         </div>
       )}
 


### PR DESCRIPTION
Implement responsive share button design to give more space to titles on mobile devices:
- Desktop: Maintain full "Share" button with dropdown chevron
- Mobile: Single compact share icon with dropdown containing all options
- Improve title flex layout with proper min-width and gap spacing
- Add aria-label for accessibility on mobile icon button

This progressive disclosure approach significantly improves mobile UX without sacrificing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)